### PR TITLE
Use vscode upcoming multiline messages

### DIFF
--- a/package.json
+++ b/package.json
@@ -150,11 +150,19 @@
                 "fileLocation": [
                     "absolute"
                 ],
-                "pattern": {
-                    "regexp": "^\\(\\d+\\) .+\\(([^\\)]+)\\): (failed in .* phase)$",
-                    "file": 1,
-                    "message": 2
-                }
+                "pattern": [
+                    {
+                        "regexp": "^\\(\\d+\\) .+\\(([^\\)]+)\\): (failed in .* phase)$",
+                        "kind": "file",
+                        "file": 1,
+                        "message": 2
+                    },
+                    {
+                        "regexp": "^    (.*)",
+                        "message": 1,
+                        "loop": true
+                    }
+                ]
             },
             {
                 "name": "autoproj-cmake-configure-error",
@@ -168,6 +176,11 @@
                         "file": 1,
                         "line": 2,
                         "message": 0
+                    },
+                    {
+                        "regexp": "(?:Autobuild::CMake|Autobuild::Orogen):(?:[^:]+):configure: (?!Call Stack)(.*)",
+                        "message": 1,
+                        "loop": true
                     }
                 ]
             },
@@ -183,6 +196,11 @@
                         "file": 1,
                         "line": 2,
                         "message": 0
+                    },
+                    {
+                        "regexp": "(?:Autobuild::CMake|Autobuild::Orogen):(?:[^:]+):configure: (?!Call Stack)(.*)",
+                        "message": 1,
+                        "loop": true
                     }
                 ]
             },

--- a/package.json
+++ b/package.json
@@ -172,13 +172,13 @@
                 ],
                 "pattern": [
                     {
-                        "regexp": "(?:Autobuild::CMake|Autobuild::Orogen):(?:[^:]+):configure: (?:.+\n)?CMake Error at ([\\/0-9a-zA-Z\\._-]+):(\\d+).*",
+                        "regexp": "(?:Autobuild::CMake|Autobuild::Orogen):(?:[^:]+):(?:configure|build): (?:.+\n)?CMake Error at ([\\/0-9a-zA-Z\\._-]+):(\\d+).*",
                         "file": 1,
                         "line": 2,
-                        "message": 0
+                        "message": -1
                     },
                     {
-                        "regexp": "(?:Autobuild::CMake|Autobuild::Orogen):(?:[^:]+):configure: (?!Call Stack)(.*)",
+                        "regexp": "(?:Autobuild::CMake|Autobuild::Orogen):(?:[^:]+):(?:configure|build): (?!Call Stack)(.*)",
                         "message": 1,
                         "loop": true
                     }
@@ -192,13 +192,13 @@
                 ],
                 "pattern": [
                     {
-                        "regexp": "(?:Autobuild::CMake|Autobuild::Orogen):(?:[^:]+):configure: (?:.+\n)?CMake Warning at ([\\/0-9a-zA-Z\\._-]+):(\\d+).*",
+                        "regexp": "(?:Autobuild::CMake|Autobuild::Orogen):(?:[^:]+):(?:configure|build): (?:.+\n)?CMake Warning at ([\\/0-9a-zA-Z\\._-]+):(\\d+).*",
                         "file": 1,
                         "line": 2,
-                        "message": 0
+                        "message": -1
                     },
                     {
-                        "regexp": "(?:Autobuild::CMake|Autobuild::Orogen):(?:[^:]+):configure: (?!Call Stack)(.*)",
+                        "regexp": "(?:Autobuild::CMake|Autobuild::Orogen):(?:[^:]+):(?:configure|build): (?!Call Stack)(.*)",
                         "message": 1,
                         "loop": true
                     }

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
         "url": "https://github.com/rock-core/vscode-rock.git"
     },
     "engines": {
-        "vscode": "^1.18.0"
+        "vscode": "^1.21.0"
     },
     "activationEvents": [
         "*"

--- a/package.json
+++ b/package.json
@@ -172,7 +172,7 @@
                 ],
                 "pattern": [
                     {
-                        "regexp": "(?:Autobuild::CMake|Autobuild::Orogen):(?:[^:]+):configure: (?:.+\n)?CMake Error at ([/0-9a-zA-Z\\._-]+):(\\d+).*",
+                        "regexp": "(?:Autobuild::CMake|Autobuild::Orogen):(?:[^:]+):configure: (?:.+\n)?CMake Error at ([\\/0-9a-zA-Z\\._-]+):(\\d+).*",
                         "file": 1,
                         "line": 2,
                         "message": 0


### PR DESCRIPTION
Built on top of #5.

This should be left here until the relevant changes in VSCode are itself merged.

Depends on:
- [x] https://github.com/Microsoft/vscode/pull/39935
- [x] https://github.com/Microsoft/vscode/pull/39936