### PR TITLE
abstract the possible choices for the package

### DIFF
--- a/src/packages.ts
+++ b/src/packages.ts
@@ -79,6 +79,27 @@ export class Type
     {
         return new Type(TypeList.CONFIG);
     }
+
+    static typePickerChoices() {
+        let choices = new Array<{
+            label: string,
+            description: string,
+            type: Type
+        }>();
+
+        TypeList.ALL_TYPES.forEach((_type) => {
+            let type = Type.fromType(_type);
+            if (!type.isInternal()) {
+                choices.push({
+                    label: type.label,
+                    description: '',
+                    type: type
+                });
+            }
+        });
+
+        return choices;
+    }
 }
 
 export class PackageFactory
@@ -189,22 +210,10 @@ abstract class GenericPackage implements Package
     }
 
     get name() { return basename(this.path); }
+
     async pickType(): Promise<void>
     {
-        let choices = new Array<{
-            label: string,
-            description: string,
-            type: Type
-        }>();
-
-        TypeList.ALL_TYPES.forEach((type) => {
-            choices.push({
-                label: type.label,
-                description: '',
-                type: Type.fromType(type)
-            });
-        });
-
+        let choices = Type.typePickerChoices();
         let options: vscode.QuickPickOptions = {
             placeHolder: 'Select the package type' }
 

--- a/src/test/packages.test.ts
+++ b/src/test/packages.test.ts
@@ -29,6 +29,16 @@ async function assertThrowsAsync(fn, msg: RegExp)
     }
 }
 
+describe("Type", function() {
+    describe("typePickerChoices", function() {
+        it("does not contain any internal type", function() {
+            packages.Type.typePickerChoices().forEach((choice) => {
+                assert(!choice.type.isInternal());
+            })
+        })
+    })
+})
+
 describe("PackageFactory", function () {
     let subject: packages.PackageFactory;
     let mockContext: TypeMoq.IMock<context.Context>;
@@ -241,20 +251,7 @@ async function testTypePicker(subject: packages.Package,
     mockContext: TypeMoq.IMock<context.Context>)
 {
     let mockWrapper = TypeMoq.Mock.ofType<wrappers.VSCode>();
-
-    let expectedChoices = new Array<{
-        label: string,
-        description: string,
-        type: packages.Type
-    }>();
-
-    packages.TypeList.ALL_TYPES.forEach((type) => {
-        expectedChoices.push({
-            label: type.label,
-            description: '',
-            type: packages.Type.fromType(type)
-        });
-    });
+    let expectedChoices = packages.Type.typePickerChoices();
     let packageType = {
         label: 'Ruby',
         description: '',


### PR DESCRIPTION
This fixes the type picker, where the two internal types started
showing up