### PR TITLE
Code improvements

### DIFF
--- a/src/autoproj.ts
+++ b/src/autoproj.ts
@@ -157,12 +157,12 @@ export function loadWorkspaceInfo(workspacePath: string): Promise<WorkspaceInfo>
         let packages = new Map()
         manifest.forEach((entry) => {
             if (entry.name) {
-                packages.set(entry.name, entry)
+                packages.set(entry.srcdir, entry)
             }
             else {
                 entry.name = entry.package_set;
                 delete entry.package_set;
-                packageSets.set(entry.name, entry)
+                packageSets.set(entry.user_local_dir, entry)
             }
         })
         return { path: workspacePath, packageSets: packageSets, packages: packages };

--- a/src/autoproj.ts
+++ b/src/autoproj.ts
@@ -55,11 +55,17 @@ export interface PackageSet
     user_local_dir: string;
 }
 
-class WorkspaceInfo
+export class WorkspaceInfo
 {
     path: string;
     packages: Map<string, Package>;
     packageSets: Map<string, PackageSet>;
+
+    constructor(path: string) {
+        this.path = path;
+        this.packages = new Map<string, Package>();
+        this.packageSets = new Map<string, PackageSet>();
+    }
 }
 
 export class Workspace

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -3,9 +3,9 @@ import * as context from './context';
 import * as packages from './packages';
 import * as wrappers from './wrappers';
 
-function assert_workspace_not_empty(context: context.Context)
+function assert_workspace_not_empty(vscode)
 {
-    if (!context.vscode.workspaceFolders || context.vscode.workspaceFolders.length == 0)
+    if (!vscode.workspaceFolders || vscode.workspaceFolders.length == 0)
         throw new Error("Current workspace is empty");
 }
 
@@ -22,7 +22,7 @@ export class Commands
 
     async selectPackage()
     {
-        assert_workspace_not_empty(this._context);
+        assert_workspace_not_empty(this._vscode);
         let choices = new Array<{ label: string,
                                   description: string,
                                   path: string }>();

--- a/src/context.ts
+++ b/src/context.ts
@@ -5,7 +5,6 @@ import * as autoproj from './autoproj';
 import * as debug from './debug';
 import * as tasks from './tasks';
 import * as packages from './packages'
-import * as async from './async'
 import * as fs from 'fs'
 import { join as joinPath } from 'path'
 
@@ -65,19 +64,16 @@ export class Context
     private readonly _workspaces: autoproj.Workspaces;
     private readonly _packageFactory: packages.PackageFactory;
     private readonly _contextUpdatedEvent: vscode.EventEmitter<void>;
-    private readonly _bridge: async.EnvironmentBridge;
     private _lastSelectedRoot: string | undefined;
 
     public constructor(vscodeWrapper: wrappers.VSCode,
                        workspaces: autoproj.Workspaces,
-                       packageFactory : packages.PackageFactory,
-                       bridge: async.EnvironmentBridge)
+                       packageFactory : packages.PackageFactory)
     {
         this._vscode = vscodeWrapper;
         this._workspaces = workspaces;
         this._contextUpdatedEvent = new vscode.EventEmitter<void>();
         this._packageFactory = packageFactory;
-        this._bridge = bridge;
     }
 
     public dispose() {
@@ -208,11 +204,6 @@ export class Context
         return this._workspaces;
     }
 
-    public get bridge(): async.EnvironmentBridge
-    {
-        return this._bridge;
-    }
-
     public debugConfig(path: string): RockDebugConfig
     {
         let resource = vscode.Uri.file(path);
@@ -284,10 +275,6 @@ export class Context
         }
     }
 
-    public getWorkspaceFolder(path: string) {
-        return this._vscode.getWorkspaceFolder(vscode.Uri.file(path));
-    }
-
     public async pickPackageType(path : string) {
         let choices = packages.Type.typePickerChoices();
         let options: vscode.QuickPickOptions = {
@@ -323,15 +310,5 @@ export class Context
             this.setDebuggingTarget(packagePath, target);
             return target;
         }
-    }
-
-    public startDebugging(path : string, options) {
-        let workspaceFolder = this.getWorkspaceFolder(path);
-        this._vscode.startDebugging(workspaceFolder, options);
-    }
-
-    public runTask(task : vscode.Task) {
-        this._vscode.executeCommand("workbench.action.tasks.runTask",
-            task.source + ": " + task.name);
     }
 }

--- a/src/context.ts
+++ b/src/context.ts
@@ -110,6 +110,16 @@ export class Context
         this._contextUpdatedEvent.fire();
     }
 
+    public getWorkspaceByPath(path : string) : autoproj.Workspace | undefined
+    {
+        return this.workspaces.folderToWorkspace.get(path);
+    }
+
+    public async getPackageByPath(path : string) : Promise<packages.Package | undefined>
+    {
+        return this._packageFactory.createPackage(path, this);
+    }
+
     public getPackageType(path: string): packages.Type | undefined
     {
         let pkgType: packages.Type | undefined;

--- a/src/context.ts
+++ b/src/context.ts
@@ -69,22 +69,14 @@ export class Context
     private _lastSelectedRoot: string | undefined;
 
     public constructor(vscodeWrapper: wrappers.VSCode,
-                       workspaces: autoproj.Workspaces = new autoproj.Workspaces,
-                       packageFactory : packages.PackageFactory | undefined = undefined,
-                       bridge: async.EnvironmentBridge | undefined = undefined)
+                       workspaces: autoproj.Workspaces,
+                       packageFactory : packages.PackageFactory,
+                       bridge: async.EnvironmentBridge)
     {
         this._vscode = vscodeWrapper;
         this._workspaces = workspaces;
         this._contextUpdatedEvent = new vscode.EventEmitter<void>();
-        if (!packageFactory) {
-            let taskProvider = new tasks.Provider(workspaces);
-            packageFactory = new packages.PackageFactory(taskProvider);
-        }
         this._packageFactory = packageFactory;
-
-        if (!bridge) {
-            bridge = new async.EnvironmentBridge;
-        }
         this._bridge = bridge;
     }
 

--- a/src/debug.ts
+++ b/src/debug.ts
@@ -61,7 +61,7 @@ export class PreLaunchTaskProvider implements vscode.TaskProvider
         }
 
         let args = ['exec', 'rock-run'];
-        let folder = context.vscode.getWorkspaceFolder(vscode.Uri.file(pkg.path)) as vscode.WorkspaceFolder;
+        let folder = context.getWorkspaceFolder(pkg.path) as vscode.WorkspaceFolder;
         let taskName = "Run " + relative(ws.root, pkg.path);
         taskName = taskName + " (gdbserver)";
 

--- a/src/debug.ts
+++ b/src/debug.ts
@@ -31,14 +31,16 @@ export class Target
 
 export class PreLaunchTaskProvider implements vscode.TaskProvider
 {
+    private readonly _vscode: wrappers.VSCode;
     private readonly _context: context.Context;
 
-    constructor(context: context.Context)
+    constructor(context: context.Context, vscode: wrappers.VSCode)
     {
+        this._vscode  = vscode;
         this._context = context;
     }
 
-    static task(pkg: packages.Package, context: context.Context): vscode.Task | undefined
+    static task(pkg: packages.Package, context: context.Context, vscode: wrappers.VSCode): vscode.Task | undefined
     {
         let ws = context.workspaces.folderToWorkspace.get(pkg.path)
         if (!ws) {
@@ -47,13 +49,13 @@ export class PreLaunchTaskProvider implements vscode.TaskProvider
 
         if (pkg.type.id === packages.TypeList.OROGEN.id)
         {
-            return this.orogenTask(ws, pkg, context);
+            return this.orogenTask(ws, pkg, context, vscode);
         }
         else {
             return;
         }
     }
-    static orogenTask(ws: autoproj.Workspace, pkg: packages.Package, context: context.Context): vscode.Task | undefined
+    static orogenTask(ws: autoproj.Workspace, pkg: packages.Package, context: context.Context, vscode: wrappers.VSCode): vscode.Task | undefined
     {
         let target = context.getDebuggingTarget(pkg.path);
         if (!target) {
@@ -61,7 +63,7 @@ export class PreLaunchTaskProvider implements vscode.TaskProvider
         }
 
         let args = ['exec', 'rock-run'];
-        let folder = context.getWorkspaceFolder(pkg.path) as vscode.WorkspaceFolder;
+        let folder = vscode.getWorkspaceFolder(pkg.path) as vscode.WorkspaceFolder;
         let taskName = "Run " + relative(ws.root, pkg.path);
         taskName = taskName + " (gdbserver)";
 
@@ -98,7 +100,7 @@ export class PreLaunchTaskProvider implements vscode.TaskProvider
             return [];
         }
 
-        let task = PreLaunchTaskProvider.task(pkg, this._context)
+        let task = PreLaunchTaskProvider.task(pkg, this._context, this._vscode)
         if (task) {
             return [task];
         }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -43,13 +43,13 @@ function setupEvents(rockContext, extensionContext, workspaces, statusBar, taskP
 // this method is called when your extension is activated
 // your extension is activated the very first time the command is executed
 export function activate(extensionContext: vscode.ExtensionContext) {
-    let envBridge = new async.EnvironmentBridge;
+    let vscodeWrapper = new wrappers.VSCode(extensionContext);
     let workspaces = new autoproj.Workspaces;
     let taskProvider = new tasks.Provider(workspaces);
-    let vscodeWrapper = new wrappers.VSCode(extensionContext);
-    let packageFactory = new packages.PackageFactory(taskProvider); 
-    let rockContext = new context.Context(vscodeWrapper,
-            workspaces, packageFactory, envBridge);
+
+    let rockContext = new context.Context(vscodeWrapper, workspaces,
+        new packages.PackageFactory(taskProvider));
+
     let statusBar = new status.StatusBar(extensionContext, rockContext);
     let rockCommands = new commands.Commands(rockContext, vscodeWrapper);
     let preLaunchTaskProvider = new debug.PreLaunchTaskProvider(rockContext);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -46,13 +46,14 @@ export function activate(extensionContext: vscode.ExtensionContext) {
     let vscodeWrapper = new wrappers.VSCode(extensionContext);
     let workspaces = new autoproj.Workspaces;
     let taskProvider = new tasks.Provider(workspaces);
+    let bridge = new async.EnvironmentBridge();
 
     let rockContext = new context.Context(vscodeWrapper, workspaces,
-        new packages.PackageFactory(taskProvider));
+        new packages.PackageFactory(vscodeWrapper, taskProvider, bridge));
 
     let statusBar = new status.StatusBar(extensionContext, rockContext);
     let rockCommands = new commands.Commands(rockContext, vscodeWrapper);
-    let preLaunchTaskProvider = new debug.PreLaunchTaskProvider(rockContext);
+    let preLaunchTaskProvider = new debug.PreLaunchTaskProvider(rockContext, vscodeWrapper);
 
     extensionContext.subscriptions.push(
         vscode.workspace.registerTaskProvider('autoproj', taskProvider));

--- a/src/packages.ts
+++ b/src/packages.ts
@@ -161,8 +161,7 @@ export class PackageFactory
             return Type.invalid();
         }
 
-        const relativePath = relative(ws.root, path)
-        let defs = wsInfo.packages.get(relativePath);
+        let defs = wsInfo.packages.get(path);
         if (!defs) {
             let wsInfo = await ws.envsh();
             return Type.fromType(TypeList.OTHER);

--- a/src/status.ts
+++ b/src/status.ts
@@ -72,9 +72,9 @@ export class StatusBar implements vscode.Disposable {
         const hide = (i: vscode.StatusBarItem) => i.hide();
         const show = (i: vscode.StatusBarItem) => i.show();
 
-        let folders = this._context.vscode.workspaceFolders;
-        if (!folders || folders.length == 0)
+        if (this._context.isWorkspaceEmpty()) {
             this._visible = false;
+        }
 
         Object.keys(this._buttons).forEach(key => {
             let item = this._buttons[key];

--- a/src/test/autoproj.test.ts
+++ b/src/test/autoproj.test.ts
@@ -50,10 +50,10 @@ describe("Autoproj helpers tests", function () {
     type: git
     url: https://github.com/rock-core/tools-rest_api.git
     repository_id: github:/rock-core/tools-rest_api.git
-  srcdir: "/home/doudou/dev/heads/tools/rest_api"
+  srcdir: "/path/to/tools/rest_api"
   builddir: 
-  logdir: "/home/doudou/dev/build_area/heads/install/tools/rest_api/log"
-  prefix: "/home/doudou/dev/heads/tools/rest_api"
+  logdir: "/path/to/install/tools/rest_api/log"
+  prefix: "/path/to/install/tools/rest_api"
   dependencies:
   - utilrb
   - tools/orocos.rb
@@ -77,10 +77,10 @@ describe("Autoproj helpers tests", function () {
             url: 'https://github.com/rock-core/tools-rest_api.git',
             repository_id: 'github:/rock-core/tools-rest_api.git'
         },
-        srcdir: "/home/doudou/dev/heads/tools/rest_api",
+        srcdir: "/path/to/tools/rest_api",
         builddir: null,
-        logdir: "/home/doudou/dev/build_area/heads/install/tools/rest_api/log",
-        prefix: "/home/doudou/dev/heads/tools/rest_api",
+        logdir: "/path/to/install/tools/rest_api/log",
+        prefix: "/path/to/install/tools/rest_api",
         dependencies: ['utilrb', 'tools/orocos.rb']
     }
 
@@ -89,8 +89,8 @@ describe("Autoproj helpers tests", function () {
             helpers.mkdir('.autoproj');
             helpers.mkfile(MANIFEST_TEST_FILE, ".autoproj", "installation-manifest");
             return autoproj.loadWorkspaceInfo(root).then(function (manifest) {
-                assert.deepStrictEqual(manifest.packageSets.get('orocos.toolchain'), PKG_SET_OROCOS_TOOLCHAIN);
-                assert.deepStrictEqual(manifest.packages.get('tools/rest_api'), PKG_TOOLS_REST_API);
+                assert.deepStrictEqual(manifest.packageSets.get('user/pkg/set/dir'), PKG_SET_OROCOS_TOOLCHAIN);
+                assert.deepStrictEqual(manifest.packages.get('/path/to/tools/rest_api'), PKG_TOOLS_REST_API);
             })
         })
         it("parses an empty manifest", function() {
@@ -128,8 +128,8 @@ describe("Autoproj helpers tests", function () {
                 helpers.mkfile(MANIFEST_TEST_FILE, ".autoproj", "installation-manifest");
                 let ws = autoproj.Workspace.fromDir(root) as autoproj.Workspace;
                 return ws.info().then(function (manifest) {
-                    assert.deepStrictEqual(manifest.packageSets.get('orocos.toolchain'), PKG_SET_OROCOS_TOOLCHAIN);
-                    assert.deepStrictEqual(manifest.packages.get('tools/rest_api'), PKG_TOOLS_REST_API);
+                    assert.deepStrictEqual(manifest.packageSets.get('user/pkg/set/dir'), PKG_SET_OROCOS_TOOLCHAIN);
+                    assert.deepStrictEqual(manifest.packages.get('/path/to/tools/rest_api'), PKG_TOOLS_REST_API);
                 })
             })
             it("creates and returns the promise if the constructor was not instructed to load it", function() {
@@ -137,8 +137,8 @@ describe("Autoproj helpers tests", function () {
                 helpers.mkfile(MANIFEST_TEST_FILE, ".autoproj", "installation-manifest");
                 let ws = autoproj.Workspace.fromDir(root, false) as autoproj.Workspace;
                 return ws.info().then(function (manifest) {
-                    assert.deepStrictEqual(manifest.packageSets.get('orocos.toolchain'), PKG_SET_OROCOS_TOOLCHAIN);
-                    assert.deepStrictEqual(manifest.packages.get('tools/rest_api'), PKG_TOOLS_REST_API);
+                    assert.deepStrictEqual(manifest.packageSets.get('user/pkg/set/dir'), PKG_SET_OROCOS_TOOLCHAIN);
+                    assert.deepStrictEqual(manifest.packages.get('/path/to/tools/rest_api'), PKG_TOOLS_REST_API);
                 })
             })
             it("does not re-resolve the info on each call", async function() {

--- a/src/test/commands.test.ts
+++ b/src/test/commands.test.ts
@@ -69,7 +69,6 @@ describe("Commands", function () {
         workspaces.addFolder(a);
         workspaces.addFolder(b);
         workspaces.addFolder(c);
-        mockContext.setup(x => x.vscode).returns(() => mockWrapper.object);
 
         let index = 0;
         workspaces.forEachFolder((ws, folder) => {

--- a/src/test/context.test.ts
+++ b/src/test/context.test.ts
@@ -57,7 +57,7 @@ class TestContext
     {
         try
         {
-            fs.unlinkSync(join(this.root, '.vscode', '.rock.json'));
+            fs.unlinkSync(join(this.root, '.vscode', 'rock.json'));
             fs.rmdirSync(join(this.root, '.vscode'));
         }
         catch {}
@@ -163,7 +163,7 @@ describe("Context tests", function () {
 
     function loadRockJson()
     {
-        let path = join(testContext.root, '.vscode', '.rock.json');
+        let path = join(testContext.root, '.vscode', 'rock.json');
         let writtenData: context.PackageInternalData;
         let jsonString = fs.readFileSync(path, 'utf8');
         writtenData = JSON.parse(jsonString);
@@ -189,7 +189,7 @@ describe("Context tests", function () {
                 }
             }
             fs.mkdirSync(join(testContext.root, '.vscode'));
-            fs.writeFileSync(join(testContext.root, '.vscode', '.rock.json'), JSON.stringify(previous));
+            fs.writeFileSync(join(testContext.root, '.vscode', 'rock.json'), JSON.stringify(previous));
             testContext.subject.setPackageType(testContext.root, type);
 
             let writtenData = loadRockJson();
@@ -202,7 +202,7 @@ describe("Context tests", function () {
             let type = packages.Type.fromName("cxx");
             let previous = "invalid json";
             fs.mkdirSync(join(testContext.root, '.vscode'));
-            fs.writeFileSync(join(testContext.root, '.vscode', '.rock.json'), previous);
+            fs.writeFileSync(join(testContext.root, '.vscode', 'rock.json'), previous);
             testContext.subject.setPackageType(testContext.root, type);
 
             let writtenData = loadRockJson();
@@ -217,7 +217,7 @@ describe("Context tests", function () {
         {
             let jsonData = JSON.stringify({ type: type });
             fs.mkdirSync(join(testContext.root, '.vscode'), 0o755);
-            fs.writeFileSync(join(testContext.root, '.vscode', '.rock.json'), jsonData);
+            fs.writeFileSync(join(testContext.root, '.vscode', 'rock.json'), jsonData);
         }
         it("reads the package type from the json file", function () {
             writeJson("orogen");
@@ -235,14 +235,14 @@ describe("Context tests", function () {
         })
         it("returns undefined if the type is unset", function () {
             fs.mkdirSync(join(testContext.root, '.vscode'), 0o755);
-            fs.writeFileSync(join(testContext.root, '.vscode', '.rock.json'),
+            fs.writeFileSync(join(testContext.root, '.vscode', 'rock.json'),
                 JSON.stringify({ data: "garbage" }));
             let type = testContext.subject.getPackageType(testContext.root);
             assert.equal(type, undefined);
         })
         it("returns undefined if the file is invalid", function () {
             fs.mkdirSync(join(testContext.root, '.vscode'), 0o755);
-            fs.writeFileSync(join(testContext.root, '.vscode', '.rock.json'), "corrupted data");
+            fs.writeFileSync(join(testContext.root, '.vscode', 'rock.json'), "corrupted data");
             let type = testContext.subject.getPackageType(testContext.root);
             assert.equal(type, undefined);
         })
@@ -262,7 +262,7 @@ describe("Context tests", function () {
             let previous = { type: "orogen" }
             let target = new debug.Target("target", "/path/to/target");
             fs.mkdirSync(join(testContext.root, '.vscode'));
-            fs.writeFileSync(join(testContext.root, '.vscode', '.rock.json'), JSON.stringify(previous));
+            fs.writeFileSync(join(testContext.root, '.vscode', 'rock.json'), JSON.stringify(previous));
             testContext.subject.setDebuggingTarget(testContext.root, target);
 
             let writtenData = loadRockJson();
@@ -275,7 +275,7 @@ describe("Context tests", function () {
             let previous = { type: "orogen" }
             let target = new debug.Target("target", "/path/to/target");
             fs.mkdirSync(join(testContext.root, '.vscode'));
-            fs.writeFileSync(join(testContext.root, '.vscode', '.rock.json'), "invalid data");
+            fs.writeFileSync(join(testContext.root, '.vscode', 'rock.json'), "invalid data");
             testContext.subject.setDebuggingTarget(testContext.root, target);
 
             let writtenData = loadRockJson();
@@ -290,7 +290,7 @@ describe("Context tests", function () {
         {
             let jsonData = JSON.stringify({ debuggingTarget: { name: name, path: path }});
             fs.mkdirSync(join(testContext.root, '.vscode'), 0o755);
-            fs.writeFileSync(join(testContext.root, '.vscode', '.rock.json'), jsonData);
+            fs.writeFileSync(join(testContext.root, '.vscode', 'rock.json'), jsonData);
         }
         it("reads the package type from the json file", function () {
             writeJson("target", "/path/to/target");
@@ -310,21 +310,18 @@ describe("Context tests", function () {
         })
         it("returns undefined if the target is unset", function () {
             fs.mkdirSync(join(testContext.root, '.vscode'), 0o755);
-            fs.writeFileSync(join(testContext.root, '.vscode', '.rock.json'),
+            fs.writeFileSync(join(testContext.root, '.vscode', 'rock.json'),
                 JSON.stringify({ data: "garbage" }));
             let target = testContext.subject.getDebuggingTarget(testContext.root);
             assert.equal(target, undefined);
         })
         it("returns undefined if the file is invalid", function () {
             fs.mkdirSync(join(testContext.root, '.vscode'), 0o755);
-            fs.writeFileSync(join(testContext.root, '.vscode', '.rock.json'), "corrupted data");
+            fs.writeFileSync(join(testContext.root, '.vscode', 'rock.json'), "corrupted data");
             let target = testContext.subject.getDebuggingTarget(testContext.root);
             assert.equal(target, undefined);
         })
     })
-    it("returns the given vscode wrapper", function () {
-        assert.strictEqual(testContext.mockWrapper.object, testContext.subject.vscode);
-    });
 
     it("returns the given workspaces", function () {
         assert.strictEqual(testContext.workspaces, testContext.subject.workspaces);
@@ -505,6 +502,127 @@ describe("Context tests", function () {
                     assert(!pkg.type.isValid());
                 });
             })
+        })
+    })
+
+    describe("pickPackageType", function() {
+        let packagePath : string;
+
+        beforeEach(function() {
+            packagePath = helpers.mkdir('package');
+            helpers.registerDir('package', '.vscode');
+            helpers.registerFile('package', '.vscode', 'rock.json');
+        })
+
+        it("selects the package type from the user-selected type", async function() {
+            let expectedChoices = packages.Type.typePickerChoices();
+            let packageType = {
+                label: 'Ruby',
+                description: '',
+                type: packages.Type.fromType(packages.TypeList.RUBY)
+            }
+            testContext.mockWrapper.setup(x => x.showQuickPick(expectedChoices, TypeMoq.It.isAny())).
+                returns(() => Promise.resolve(packageType));
+
+            await testContext.subject.pickPackageType(packagePath);
+            const selectedPackageType = testContext.subject.getPackageType(packagePath);
+            assert(selectedPackageType);
+            if (selectedPackageType) {
+                assert.equal(selectedPackageType.id, packages.TypeList.RUBY.id);
+            }
+        })
+
+        it("does not modify the selection if the picker is cancelled", async function() {
+            testContext.mockWrapper.setup(x => x.showQuickPick(TypeMoq.It.isAny(), TypeMoq.It.isAny())).
+                returns(() => Promise.resolve(undefined));
+
+            testContext.subject.setPackageType(packagePath, packages.Type.fromName('cxx'));
+            await testContext.subject.pickPackageType(packagePath);
+            const selectedPackageType = testContext.subject.getPackageType(packagePath);
+            assert.deepEqual(selectedPackageType, packages.Type.fromName('cxx'));
+        })
+    })
+
+    describe("pickDebuggingTarget", function() {
+        let packagePath : string;
+
+        beforeEach(function() {
+            packagePath = helpers.mkdir('package');
+            helpers.registerDir('package', '.vscode');
+            helpers.registerFile('package', '.vscode', 'rock.json');
+        })
+
+        it("selects the package target from the provided list", async function() {
+            let choices : context.DebuggingTargetChoice[] = [
+                {
+                    'label': 'label1',
+                    'description': 'descriptiont1',
+                    'targetName': 'name1',
+                    'targetFile': 'path1'
+                },
+                {
+                    'label': 'label2',
+                    'description': 'descriptiont2',
+                    'targetName': 'name2',
+                    'targetFile': 'path2'
+                }
+            ];
+
+            testContext.mockWrapper.setup(x => x.showQuickPick(choices, TypeMoq.It.isAny(), TypeMoq.It.isAny())).
+                returns(() => Promise.resolve(choices[0]));
+
+            await testContext.subject.pickDebuggingTarget(packagePath, choices, {}, undefined);
+            const selectedTarget = testContext.subject.getDebuggingTarget(packagePath);
+            assert(selectedTarget);
+            if (selectedTarget) {
+                assert.equal(selectedTarget.name, 'name1');
+                assert.equal(selectedTarget.path, 'path1');
+            }
+        })
+
+        it("does not modify the selection if the picker is cancelled", async function() {
+            testContext.mockWrapper.setup(x => x.showQuickPick(TypeMoq.It.isAny(), TypeMoq.It.isAny())).
+                returns(() => Promise.resolve(undefined));
+
+            let expected = new debug.Target('name', 'path')
+            testContext.subject.setDebuggingTarget(packagePath, expected);
+            await testContext.subject.pickDebuggingTarget(packagePath, [], {}, undefined);
+            const selectedTarget = testContext.subject.getDebuggingTarget(packagePath);
+            assert.deepEqual(expected, selectedTarget);
+        })
+    })
+
+    describe("pickDebuggingFile", function() {
+        let packagePath : string;
+
+        beforeEach(function() {
+            packagePath = helpers.mkdir('package');
+            helpers.registerDir('package', '.vscode');
+            helpers.registerFile('package', '.vscode', 'rock.json');
+        })
+
+        it("selects the package target from the file system", async function() {
+            testContext.mockWrapper.setup(x => x.showOpenDialog(TypeMoq.It.isAny())).
+                returns(() => Promise.resolve([vscode.Uri.file('/picked/file')]));
+
+            await testContext.subject.pickDebuggingFile(packagePath);
+            const selectedTarget = testContext.subject.getDebuggingTarget(packagePath);
+            assert(selectedTarget);
+            if (selectedTarget) {
+                assert.equal(selectedTarget.name, 'file');
+                assert.equal(selectedTarget.path, '/picked/file');
+            }
+        })
+
+        it("does not modify the selection if the picker is cancelled", async function() {
+            testContext.mockWrapper.setup(x => x.showOpenDialog(TypeMoq.It.isAny())).
+                returns(() => Promise.resolve(undefined));
+
+            let expected = new debug.Target('name', 'path')
+            testContext.subject.setDebuggingTarget(packagePath, expected);
+            await testContext.subject.pickDebuggingFile(packagePath);
+            const selectedTarget = testContext.subject.getDebuggingTarget(packagePath);
+            assert.deepEqual(expected, selectedTarget);
         })
     })
 });

--- a/src/test/context.test.ts
+++ b/src/test/context.test.ts
@@ -38,17 +38,16 @@ class TestContext
             .returns(() => this._activeDocumentURI);
         this.mockContext = TypeMoq.Mock.ofType<vscode.ExtensionContext>();
         let taskProvider = TypeMoq.Mock.ofType<tasks.Provider>();
-        let packageFactory = new packages.PackageFactory(taskProvider.object);
+        this.mockBridge = TypeMoq.Mock.ofType<async.EnvironmentBridge>();
+        let packageFactory = new packages.PackageFactory(this.mockWrapper.object, taskProvider.object, this.mockBridge.object);
         this.mockPackageFactory = TypeMoq.Mock.ofInstance(packageFactory);
         this.mockPackageFactory.callBase = true;
-        this.mockBridge = TypeMoq.Mock.ofType<async.EnvironmentBridge>();
         this.workspaces = new autoproj.Workspaces;
 
         this.subject = new context.Context(
             this.mockWrapper.object,
             this.workspaces,
-            this.mockPackageFactory.object,
-            this.mockBridge.object);
+            this.mockPackageFactory.object);
 
         this.mockWorkspaceConf = TypeMoq.Mock.ofType<vscode.WorkspaceConfiguration>();
     }
@@ -325,10 +324,6 @@ describe("Context tests", function () {
 
     it("returns the given workspaces", function () {
         assert.strictEqual(testContext.workspaces, testContext.subject.workspaces);
-    });
-
-    it("returns the given environment bridge", function () {
-        assert.strictEqual(testContext.mockBridge.object, testContext.subject.bridge);
     });
 
     it("gets the package selection mode", function () {

--- a/src/test/debug.test.ts
+++ b/src/test/debug.test.ts
@@ -63,10 +63,10 @@ class TestContext
         mockPkg.setup(x => x.type).returns(() => type);
         return mockPkg;
     }
-    associateResourceWithFolder(resource: vscode.Uri,
+    associateResourceWithFolder(path: string,
         folder: vscode.WorkspaceFolder): void
     {
-        this.mockWrapper.setup(x => x.getWorkspaceFolder(resource)).
+        this.mockContext.setup(x => x.getWorkspaceFolder(path)).
             returns(() => folder);
     }
     setDebuggingConfigurationForPkg(path: string, config: context.RockDebugConfig)
@@ -122,9 +122,8 @@ describe("Pre Launch Task Provider", function () {
                 index: 0
             };
 
-            let resource = vscode.Uri.file(a);
             test.setSelectedPackage(a, packages.Type.fromType(packages.TypeList.OROGEN));
-            test.associateResourceWithFolder(resource, folder);
+            test.associateResourceWithFolder(a, folder);
             test.setDebuggingConfigurationForPkg(a, userConf);
             let target = test.setDebuggingTargetForPackage(a);
             let tasks = await test.subject.provideTasks();

--- a/src/test/debug.test.ts
+++ b/src/test/debug.test.ts
@@ -39,12 +39,11 @@ class TestContext
 
         let ctxt = new context.Context(this.mockWrapper.object,
             workspaces,
-            mockFactory.object,
-            mockBridge.object);
+            mockFactory.object);
         this.mockContext = TypeMoq.Mock.ofInstance(ctxt);
         this.mockContext.callBase = true;
         this.subject = new debug.PreLaunchTaskProvider(
-            this.mockContext.object);
+            this.mockContext.object, this.mockWrapper.object);
     }
 
     setDebuggingTargetForPackage(path: string): debug.Target
@@ -66,7 +65,7 @@ class TestContext
     associateResourceWithFolder(path: string,
         folder: vscode.WorkspaceFolder): void
     {
-        this.mockContext.setup(x => x.getWorkspaceFolder(path)).
+        this.mockWrapper.setup(x => x.getWorkspaceFolder(path)).
             returns(() => folder);
     }
     setDebuggingConfigurationForPkg(path: string, config: context.RockDebugConfig)

--- a/src/test/helpers.ts
+++ b/src/test/helpers.ts
@@ -32,6 +32,14 @@ export function mkfile(data: string, ...path): string {
     createdFS.push([joinedPath, 'file']);
     return joinedPath;
 }
+export function registerDir(...path) {
+    let joinedPath = Path.join(root, ...path);
+    createdFS.push([joinedPath, 'dir']);
+}
+export function registerFile(...path) {
+    let joinedPath = Path.join(root, ...path);
+    createdFS.push([joinedPath, 'file']);
+}
 export function createInstallationManifest(data: any, ...workspacePath): string {
     let joinedPath = Path.join(root, ...workspacePath);
     joinedPath = Autoproj.installationManifestPath(joinedPath);

--- a/src/wrappers.ts
+++ b/src/wrappers.ts
@@ -1,4 +1,5 @@
 import * as vscode from 'vscode'
+import * as Path from 'path'
 
 /** Shim that provides us an API to the VSCode state we need within the extension
  * 

--- a/src/wrappers.ts
+++ b/src/wrappers.ts
@@ -29,8 +29,11 @@ export class VSCode {
         return vscode.workspace.workspaceFolders;
     }
 
-    public getWorkspaceFolder(uri: vscode.Uri): vscode.WorkspaceFolder | undefined
+    public getWorkspaceFolder(uri: vscode.Uri | string): vscode.WorkspaceFolder | undefined
     {
+        if (typeof uri == 'string') {
+            uri = vscode.Uri.file(uri);
+        }
         return vscode.workspace.getWorkspaceFolder(uri);
     }
 
@@ -62,8 +65,11 @@ export class VSCode {
         return vscode.window.showOpenDialog(options);
     }
 
-    public startDebugging(folder: vscode.WorkspaceFolder | undefined, nameOrConfiguration: string | vscode.DebugConfiguration): Thenable<boolean>
+    public startDebugging(folder: vscode.WorkspaceFolder | string | undefined, nameOrConfiguration: string | vscode.DebugConfiguration): Thenable<boolean>
     {
+        if (typeof folder == 'string') {
+            folder = this.getWorkspaceFolder(folder);
+        }
         return vscode.debug.startDebugging(folder, nameOrConfiguration);
     }
 
@@ -80,5 +86,11 @@ export class VSCode {
     public updateWorkspaceState(key : string, value : string | undefined)
     {
         this._extensionContext.workspaceState.update(key, value);
+    }
+
+    public runTask(task : vscode.Task)
+    {
+        vscode.commands.executeCommand("workbench.action.tasks.runTask",
+            task.source + ": " + task.name);
     }
 }


### PR DESCRIPTION
The first change is to get rid of most of the Demeter chains that do not make sense. This is really because I'm getting headaches when I try to follow the mock chains. The good side effect IMO is that it improves the interfaces.

Other changes:
- WorkspaceInfo uses the package directory as key
- RockPackage subclasses contain the autoproj.Package as field.
  