### PR TITLE
Use launch.json to start and debug processes

### DIFF
--- a/src/autoproj.ts
+++ b/src/autoproj.ts
@@ -215,6 +215,12 @@ export class Workspaces
         }
     }
 
+    /** Associate a folder to a workspace
+     */
+    associateFolderToWorkspace(path: string, workspace: Workspace) {
+        this.folderToWorkspace.set(path, workspace);
+    }
+
     /** Add a folder
      * 
      * This adds the folder's workspace to the set, if the folder is part of an
@@ -224,7 +230,7 @@ export class Workspaces
     addFolder(path: string) {
         let { added, workspace } = this.addCandidate(path);
         if (workspace) {
-            this.folderToWorkspace.set(path, workspace);
+            this.associateFolderToWorkspace(path, workspace);
         }
         return workspace;
     }

--- a/src/autoproj.ts
+++ b/src/autoproj.ts
@@ -137,6 +137,28 @@ export class Workspace
             })
         })
     }
+
+    async which(cmd: string)
+    {
+        let options: child_process.SpawnOptions = {};
+        options.env = { AUTOPROJ_CURRENT_ROOT: this.root };
+        let subprocess = child_process.spawn(this.autoprojExePath(), ['which', cmd], options);
+        let path = '';
+        subprocess.stdout.on('data', (buffer) => {
+            path = path.concat(buffer.toString());
+        })
+
+        return new Promise<string>((resolve, reject) => {
+            subprocess.on('close', (code, signal) => {
+                if (code !== 0) {
+                    reject(`cannot find ${cmd} in the workspace`)
+                }
+                else {
+                    resolve(path.trim());
+                }
+            })
+        })
+    }
 }
 
 export function loadWorkspaceInfo(workspacePath: string): Promise<WorkspaceInfo>

--- a/src/autoproj.ts
+++ b/src/autoproj.ts
@@ -89,7 +89,9 @@ export class Workspace
     {
         this.root = root;
         this.name = path.basename(root);
-        this._info = this.createInfoPromise();
+        if (loadInfo) {
+            this._info = this.createInfoPromise();
+        }
     }
 
     autoprojExePath() {
@@ -99,6 +101,10 @@ export class Workspace
     private createInfoPromise()
     {
         return loadWorkspaceInfo(this.root);
+    }
+
+    loadingInfo() : boolean {
+        return this._info !== undefined;
     }
 
     async reload()
@@ -219,7 +225,7 @@ export class Workspaces
      * 
      * Returns the list of newly added workspaces
      */
-    addCandidate(path: string) {
+    addCandidate(path: string, loadInfo: boolean = true) {
         // Workspaces are often duplicates (multiple packages from the same ws).
         // Make sure we don't start the info resolution promise until we're sure
         // it is new
@@ -232,7 +238,9 @@ export class Workspaces
         }
         else {
             this.add(ws);
-            ws.info();
+            if (loadInfo) {
+                ws.info();
+            }
             return { added: true, workspace: ws };
         }
     }

--- a/src/autoproj.ts
+++ b/src/autoproj.ts
@@ -155,9 +155,9 @@ export class Workspace
         })
 
         return new Promise<string>((resolve, reject) => {
-            subprocess.on('close', (code, signal) => {
+            subprocess.on('exit', (code, signal) => {
                 if (code !== 0) {
-                    reject(`cannot find ${cmd} in the workspace`)
+                    reject(new Error(`cannot find ${cmd} in the workspace`))
                 }
                 else {
                     resolve(path.trim());

--- a/src/debug.ts
+++ b/src/debug.ts
@@ -114,3 +114,30 @@ export class PreLaunchTaskProvider implements vscode.TaskProvider
         return null;
     }
 }
+
+export class DebugConfigurationProvider implements vscode.DebugConfigurationProvider
+{
+    private _context : context.Context;
+
+    constructor(context : context.Context) {
+        this._context = context;
+    }
+
+    provideDebugConfigurations(folder : vscode.WorkspaceFolder | undefined, token : vscode.CancellationToken | undefined) : vscode.ProviderResult<vscode.DebugConfiguration[]> {
+        return [];
+    }
+
+    async resolveDebugConfiguration(folder : vscode.WorkspaceFolder | undefined, debugConfig : vscode.DebugConfiguration, token : vscode.CancellationToken | undefined) : Promise<vscode.DebugConfiguration>
+    {
+        if (!folder) {
+            return debugConfig;
+        }
+
+        let pkg = await this._context.getPackageByPath(folder.uri.fsPath);
+        if (!pkg) {
+            return debugConfig;
+        }
+
+        return pkg.resolveDebugConfiguration(debugConfig);
+    }
+}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -82,6 +82,7 @@ export function activate(extensionContext: vscode.ExtensionContext) {
 
     let debugProvider = new debug.DebugConfigurationProvider(rockContext);
     extensionContext.subscriptions.push(vscode.debug.registerDebugConfigurationProvider('cppdbg', debugProvider));
+    extensionContext.subscriptions.push(vscode.debug.registerDebugConfigurationProvider('Ruby', debugProvider));
 
     statusBar.update();
     extensionContext.subscriptions.push(statusBar);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -80,9 +80,10 @@ export function activate(extensionContext: vscode.ExtensionContext) {
         statusBar, taskProvider, configManager);
     rockCommands.register();
 
-    let debugProvider = new debug.DebugConfigurationProvider(rockContext);
-    extensionContext.subscriptions.push(vscode.debug.registerDebugConfigurationProvider('cppdbg', debugProvider));
-    extensionContext.subscriptions.push(vscode.debug.registerDebugConfigurationProvider('Ruby', debugProvider));
+    let cppDebugProvider = new debug.CXXConfigurationProvider(rockContext);
+    extensionContext.subscriptions.push(vscode.debug.registerDebugConfigurationProvider('cppdbg', cppDebugProvider));
+    let rubyDebugProvider = new debug.RubyConfigurationProvider(rockContext);
+    extensionContext.subscriptions.push(vscode.debug.registerDebugConfigurationProvider('Ruby', rubyDebugProvider));
 
     statusBar.update();
     extensionContext.subscriptions.push(statusBar);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -80,6 +80,9 @@ export function activate(extensionContext: vscode.ExtensionContext) {
         statusBar, taskProvider, configManager);
     rockCommands.register();
 
+    let debugProvider = new debug.DebugConfigurationProvider(rockContext);
+    extensionContext.subscriptions.push(vscode.debug.registerDebugConfigurationProvider('cppdbg', debugProvider));
+
     statusBar.update();
     extensionContext.subscriptions.push(statusBar);
     extensionContext.subscriptions.push(rockContext);

--- a/src/packages.ts
+++ b/src/packages.ts
@@ -5,6 +5,7 @@ import * as tasks from './tasks'
 import * as wrappers from './wrappers'
 import * as autoproj from './autoproj'
 import * as async from './async'
+import * as fs from 'fs'
 import { relative, basename, dirname } from 'path'
 
 export class TypeList
@@ -127,16 +128,20 @@ export class PackageFactory
         }
         else if (context.getWorkspaceByPath(path))
         {
-            let info = await this.packageInfo(path, context);
+            let { ws, info } = await this.packageInfo(path, context);
+            if (!ws) {
+                return new ForeignPackage(path, context);
+            }
+
             let type = await this.packageType(path, context, info);
             switch (type.id)
             {
                 case TypeList.CXX.id:
-                    return new RockCXXPackage(info, context, this._vscode, this._taskProvider);
+                    return new RockCXXPackage(ws, info, context, this._vscode, this._taskProvider);
                 case TypeList.RUBY.id:
-                    return new RockRubyPackage(this._bridge, info, context, this._vscode, this._taskProvider);
+                    return new RockRubyPackage(this._bridge, ws, info, context, this._vscode, this._taskProvider);
                 case TypeList.OROGEN.id:
-                    return new RockOrogenPackage(this._bridge, info, context, this._vscode, this._taskProvider);
+                    return new RockOrogenPackage(this._bridge, ws, info, context, this._vscode, this._taskProvider);
                 default:
                     return new RockOtherPackage(path, context, this._vscode, this._taskProvider);
             }
@@ -163,18 +168,18 @@ export class PackageFactory
         return result;
     }
 
-    private async packageInfo(path: string, context: context.Context): Promise<autoproj.Package>
+    private async packageInfo(path: string, context: context.Context): Promise<{ ws: autoproj.Workspace | null, info: autoproj.Package}>
     {
         const ws = context.getWorkspaceByPath(path);
         if (!ws)
-            return this.nullPackageInfo(path);
+            return { ws: null, info: this.nullPackageInfo(path) };
 
         let wsInfo;
         try {
             wsInfo = await ws.info();
         }
         catch(err) {
-            return this.nullPackageInfo(path);
+            return { ws, info: this.nullPackageInfo(path) };
         }
 
         let defs = wsInfo.packages.get(path);
@@ -182,14 +187,14 @@ export class PackageFactory
             let wsInfo = await ws.envsh();
             let defs = wsInfo.packages.get(path);
             if (defs) {
-                return defs;
+                return { ws, info: defs };
             }
             else {
-                return this.nullPackageInfo(path);
+                return { ws, info: this.nullPackageInfo(path) };
             }
         }
         else {
-            return defs;
+            return { ws, info: defs };
         }
     }
 
@@ -253,6 +258,7 @@ abstract class GenericPackage implements Package
 abstract class RockPackage extends GenericPackage
 {
     protected readonly _vscode: wrappers.VSCode;
+    readonly ws: autoproj.Workspace;
     readonly info: autoproj.Package;
 
     get path() : string
@@ -263,10 +269,11 @@ abstract class RockPackage extends GenericPackage
     readonly debugable : boolean;
     private readonly _taskProvider: tasks.Provider;
 
-    constructor(info: autoproj.Package, context: context.Context, vscode: wrappers.VSCode, taskProvider: tasks.Provider)
+    constructor(ws: autoproj.Workspace, info: autoproj.Package, context: context.Context, vscode: wrappers.VSCode, taskProvider: tasks.Provider)
     {
         super(context);
         this._vscode = vscode;
+        this.ws = ws;
         this.info = info;
         this.debugable = true;
         this._taskProvider = taskProvider;
@@ -426,9 +433,9 @@ export class RockRubyPackage extends RockPackageWithTargetPicker
 {
     private _bridge: async.EnvironmentBridge;
 
-    constructor(bridge: async.EnvironmentBridge, info: autoproj.Package, context: context.Context, vscode: wrappers.VSCode, taskProvider: tasks.Provider)
+    constructor(bridge: async.EnvironmentBridge, ws: autoproj.Workspace, info: autoproj.Package, context: context.Context, vscode: wrappers.VSCode, taskProvider: tasks.Provider)
     {
-        super(info, context, vscode, taskProvider);
+        super(ws, info, context, vscode, taskProvider);
         this._bridge = bridge;
     }
 
@@ -498,9 +505,9 @@ export class RockOrogenPackage extends RockPackage
 {
     private _bridge: async.EnvironmentBridge;
 
-    constructor(bridge: async.EnvironmentBridge, info: autoproj.Package, context: context.Context, vscode: wrappers.VSCode, taskProvider: tasks.Provider)
+    constructor(bridge: async.EnvironmentBridge, ws: autoproj.Workspace, info: autoproj.Package, context: context.Context, vscode: wrappers.VSCode, taskProvider: tasks.Provider)
     {
-        super(info, context, vscode, taskProvider);
+        super(ws, info, context, vscode, taskProvider);
         this._bridge = bridge;
     }
 

--- a/src/packages.ts
+++ b/src/packages.ts
@@ -6,7 +6,8 @@ import * as wrappers from './wrappers'
 import * as autoproj from './autoproj'
 import * as async from './async'
 import * as fs from 'fs'
-import { relative, basename, dirname } from 'path'
+import * as child_process from 'child_process'
+import { relative, basename, dirname, join as joinpath } from 'path'
 
 export class TypeList
 {
@@ -456,6 +457,18 @@ export class RockRubyPackage extends RockPackageWithTargetPicker
 
     async preLaunchTask(): Promise<void>
     {
+    }
+
+    async resolveDebugConfiguration(config: vscode.DebugConfiguration): Promise<vscode.DebugConfiguration>
+    {
+        config.useBundler = true;
+        config.pathToBundler = this.ws.autoprojExePath();
+        if (!config.env) {
+            config.env = {}
+        }
+        config.env.AUTOPROJ_CURRENT_ROOT = this.ws.root;
+        config.program = await this.ws.which(config.program);
+        return config;
     }
 
     async debugConfiguration(): Promise<vscode.DebugConfiguration>

--- a/src/packages.ts
+++ b/src/packages.ts
@@ -223,6 +223,7 @@ export interface Package
     readonly buildTask: vscode.Task | undefined;
     readonly debugTarget: debug.Target | undefined;
 
+    resolveDebugConfiguration(config: vscode.DebugConfiguration): Promise<vscode.DebugConfiguration>
     debug(): Promise<void>
     build(): Promise<void>
     pickTarget(): Promise<void>
@@ -248,6 +249,11 @@ abstract class GenericPackage implements Package
     }
 
     get name() { return basename(this.path); }
+
+    async resolveDebugConfiguration(config: vscode.DebugConfiguration): Promise<vscode.DebugConfiguration>
+    {
+        return config;
+    }
 
     async pickType(): Promise<void>
     {
@@ -324,6 +330,11 @@ export class InvalidPackage implements Package
     readonly debugTarget: debug.Target | undefined;
 
     get name () { return '(Invalid package)' }
+    async resolveDebugConfiguration(config: vscode.DebugConfiguration): Promise<vscode.DebugConfiguration>
+    {
+        return config;
+    }
+
     async debug(): Promise<void>
     {
         throw new Error("Select a valid package before starting a debugging session");
@@ -364,6 +375,10 @@ export class ConfigPackage implements Package
     }
 
     get name() { return basename(this.path); }
+    async resolveDebugConfiguration(config: vscode.DebugConfiguration): Promise<vscode.DebugConfiguration>
+    {
+        return config;
+    }
     async debug(): Promise<void>
     {
         throw new Error("Debugging a configuration package is not possible");
@@ -466,6 +481,39 @@ export class RockRubyPackage extends RockPackageWithTargetPicker
 
 export class RockCXXPackage extends RockPackageWithTargetPicker
 {
+    async resolveDebugConfiguration(config: vscode.DebugConfiguration): Promise<vscode.DebugConfiguration>
+    {
+        let debuggerPath = config.miDebuggerPath || config.MIMode;
+        let stubScript = joinpath(__dirname, '..', 'stubs', config.MIMode);
+
+        config.miDebuggerPath = stubScript;
+        if (!config.environment) {
+            config.environment = [];
+        }
+        config.environment = config.environment.concat([
+            { name: "VSCODE_ROCK_AUTOPROJ_PATH", value: this.ws.autoprojExePath() },
+            { name: "VSCODE_ROCK_AUTOPROJ_DEBUGGER", value: debuggerPath },
+            { name: 'AUTOPROJ_CURRENT_ROOT', value: this.ws.root }
+        ])
+
+        if (!fs.existsSync(config.program)) {
+            let search = [this.info.builddir, this.info.prefix,
+                joinpath(this.info.builddir, 'test'),
+                joinpath(this.info.builddir, 'src'),
+                joinpath(this.info.prefix, 'bin')]
+            let foundPath = search.find((dir) => {
+                return fs.existsSync(joinpath(dir, config.program));
+            })
+            if (foundPath) {
+                config.program = joinpath(foundPath, config.program);
+            }
+        }
+        if (!config.cwd) {
+            config.cwd = dirname(config.program);
+        }
+        return config;
+    }
+
     async preLaunchTask(): Promise<void>
     {
     }

--- a/src/test/autoproj.test.ts
+++ b/src/test/autoproj.test.ts
@@ -105,6 +105,18 @@ describe("Autoproj helpers tests", function () {
     })
 
     describe("Workspace", function() {
+        describe("constructor", function() {
+            it("starts the info loading by default", function() {
+                helpers.mkdir('.autoproj');
+                helpers.createInstallationManifest([]);
+                let ws = new autoproj.Workspace("path");
+                assert(ws.loadingInfo());
+            })
+            it("does not start the info loading if the loadInfo flag is false", function() {
+                let ws = new autoproj.Workspace("path", false);
+                assert(!ws.loadingInfo());
+            })
+        })
         describe("fromDir", function() {
             it("returns null when called outside a workspace", function() {
                 helpers.mkdir('.autoproj');

--- a/src/test/debug.test.ts
+++ b/src/test/debug.test.ts
@@ -151,20 +151,23 @@ describe("Pre Launch Task Provider", function () {
                 builddir: "/path/to/build",
                 prefix: "/path/to/prefix"
             }
-            it("replaces the srcdir", function() {
-                let expanded = subject.expandAutoprojPaths(pkg, "before:${rock:srcDir}:after")
+            it("replaces the srcdir", async function() {
+                let expanded = await subject.expandAutoprojPaths((name) => Promise.resolve(""), pkg, "before:${rock:srcDir}:after")
                 assert.equal("before:/path/to/src:after", expanded);
             })
-            it("replaces the builddir", function() {
-                let expanded = subject.expandAutoprojPaths(pkg, "before:${rock:buildDir}:after")
+            it("replaces the builddir", async function() {
+                let expanded = await subject.expandAutoprojPaths((name) => Promise.resolve(""), pkg, "before:${rock:buildDir}:after")
                 assert.equal("before:/path/to/build:after", expanded);
             })
-            it("replaces the prefix", function() {
-                let expanded = subject.expandAutoprojPaths(pkg, "before:${rock:prefixDir}:after")
+            it("replaces the prefix", async function() {
+                let expanded = await subject.expandAutoprojPaths((name) => Promise.resolve(""), pkg, "before:${rock:prefixDir}:after")
                 assert.equal("before:/path/to/prefix:after", expanded);
             })
+            it("resolves a command using 'which'", async function() {
+                let expanded = await subject.expandAutoprojPaths((name) => Promise.resolve(`/path/to/${name}`), pkg, "before:${rock:which:test}:after")
+                assert.equal("before:/path/to/test:after", expanded);
+            })
         })
-
     })
 
     describe("in a non empty workspace", function () {

--- a/src/test/debug.test.ts
+++ b/src/test/debug.test.ts
@@ -93,6 +93,80 @@ describe("Pre Launch Task Provider", function () {
         assert.deepEqual(actual_args, args);
     }
 
+    describe("in an empty workspace", function () {
+        let test: TestContext;
+        beforeEach(function () {
+            test = new TestContext(workspaces);
+        });
+        it("provides an empty array of tasks", async function () {
+            let tasks = await test.subject.provideTasks();
+            assert.equal(tasks.length, 0);
+        })
+    });
+
+    describe("ConfigurationProvider", function() {
+        let root: string;
+        let s: helpers.TestSetup;
+        let subject: debug.ConfigurationProvider;
+        let mock;
+        let ws;
+        beforeEach(function() {
+            root = helpers.init();
+            s = new helpers.TestSetup();
+            subject = new debug.ConfigurationProvider(s.context);
+            let result = s.createAndRegisterWorkspace('test');
+            ws = result.ws;
+        })
+
+        describe("resolvePackage", function() {
+            it("returns undefined for an undefined workspace folder", async function() {
+                let pkg = await subject.resolvePackage(undefined)
+                assert.strictEqual(pkg, undefined);
+            })
+            it("returns the package if it is a RockPackage", async function() {
+                let pkg = await s.registerPackage(ws, ['test'], { type: 'Autobuild::CMake' })
+                let folder: vscode.WorkspaceFolder = {
+                    uri: vscode.Uri.file(pkg.path),
+                    name: "package",
+                    index: 0
+                };
+                let resolved = await subject.resolvePackage(folder);
+                assert.deepStrictEqual(resolved, pkg);
+            })
+            it("returns undefined if the package is not a RockPackage", async function() {
+                let pkg = await s.registerPackage(ws, ['test'], { type: '' })
+                let folder: vscode.WorkspaceFolder = {
+                    uri: vscode.Uri.file(pkg.path),
+                    name: "package",
+                    index: 0
+                };
+                let resolved = await subject.resolvePackage(folder);
+                assert.strictEqual(resolved, undefined);
+            })
+        })
+
+        describe("expandAutoprojPaths", function() {
+            let pkg = {
+                srcdir: "/path/to/src",
+                builddir: "/path/to/build",
+                prefix: "/path/to/prefix"
+            }
+            it("replaces the srcdir", function() {
+                let expanded = subject.expandAutoprojPaths(pkg, "before:${rock:srcDir}:after")
+                assert.equal("before:/path/to/src:after", expanded);
+            })
+            it("replaces the builddir", function() {
+                let expanded = subject.expandAutoprojPaths(pkg, "before:${rock:buildDir}:after")
+                assert.equal("before:/path/to/build:after", expanded);
+            })
+            it("replaces the prefix", function() {
+                let expanded = subject.expandAutoprojPaths(pkg, "before:${rock:prefixDir}:after")
+                assert.equal("before:/path/to/prefix:after", expanded);
+            })
+        })
+
+    })
+
     describe("in a non empty workspace", function () {
         let a: string;
         let test: TestContext;
@@ -139,15 +213,5 @@ describe("Pre Launch Task Provider", function () {
             assert.deepEqual(actual_args, args);
             assert.equal(tasks[0].scope, folder);
         });
-    });
-    describe("in an empty workspace", function () {
-        let test: TestContext;
-        beforeEach(function () {
-            test = new TestContext(workspaces);
-        });
-        it("provides an empty array of tasks", async function () {
-            let tasks = await test.subject.provideTasks();
-            assert.equal(tasks.length, 0);
-        })
     });
 });

--- a/src/test/helpers.ts
+++ b/src/test/helpers.ts
@@ -1,11 +1,19 @@
 'use strict';
 
+import * as vscode from 'vscode'
 import * as Autoproj from '../autoproj'
 import * as FS from 'fs';
 import * as Temp from 'fs-temp';
 import * as Path from 'path';
 import * as YAML from 'js-yaml';
 import * as assert from 'assert'
+import * as TypeMoq from 'typemoq'
+import * as Wrappers from '../wrappers'
+import * as Context from '../context'
+import * as Packages from '../packages'
+import * as Tasks from '../tasks'
+import * as Async from '../async'
+import { writeFileSync } from 'fs';
 
 export async function assertThrowsAsync(fn, msg: RegExp)
 {
@@ -31,6 +39,9 @@ export function init(): string {
     return root;
 }
 
+export function fullPath(...path : string[]): string {
+    return Path.join(root, ...path);
+}
 export function mkdir(...path): string {
     let joinedPath = root;
     path.forEach((element) => {
@@ -44,21 +55,21 @@ export function mkdir(...path): string {
     return joinedPath;
 }
 export function mkfile(data: string, ...path): string {
-    let joinedPath = Path.join(root, ...path);
+    let joinedPath = fullPath(...path);
     FS.writeFileSync(joinedPath, data)
     createdFS.push([joinedPath, 'file']);
     return joinedPath;
 }
 export function registerDir(...path) {
-    let joinedPath = Path.join(root, ...path);
+    let joinedPath = fullPath(...path);
     createdFS.push([joinedPath, 'dir']);
 }
 export function registerFile(...path) {
-    let joinedPath = Path.join(root, ...path);
+    let joinedPath = fullPath(...path);
     createdFS.push([joinedPath, 'file']);
 }
 export function createInstallationManifest(data: any, ...workspacePath): string {
-    let joinedPath = Path.join(root, ...workspacePath);
+    let joinedPath = fullPath(...workspacePath);
     joinedPath = Autoproj.installationManifestPath(joinedPath);
     mkdir(...workspacePath, '.autoproj')
     FS.writeFileSync(joinedPath, YAML.safeDump(data));
@@ -67,14 +78,125 @@ export function createInstallationManifest(data: any, ...workspacePath): string 
 }
 export function clear() {
     createdFS.reverse().forEach((entry) => {
-        if (entry[1] === "file") {
-            FS.unlinkSync(entry[0]);
+        try {
+            if (entry[1] === "file") {
+                FS.unlinkSync(entry[0]);
+            }
+            else if (entry[1] === "dir") {
+                FS.rmdirSync(entry[0]);
+            }
         }
-        else if (entry[1] === "dir") {
-            FS.rmdirSync(entry[0]);
+        catch(error) {
+            if (!(error.message =~ /ENOENT/)) {
+                throw error;
+            }
         }
     })
     createdFS = []
     FS.rmdirSync(root)
     root = null
 }
+
+export class TestSetup
+{
+    mockWrapper : TypeMoq.IMock<Wrappers.VSCode>;
+    mockBridge : TypeMoq.IMock<Async.EnvironmentBridge>;
+
+    mockWorkspaces: TypeMoq.IMock<Autoproj.Workspaces>;
+    get workspaces()
+    {
+        return this.mockWorkspaces.target;
+    }
+
+    mockTaskProvider : TypeMoq.IMock<Tasks.Provider>;
+    get taskProvider()
+    {
+        return this.mockTaskProvider.target;
+    }
+
+    mockPackageFactory : TypeMoq.IMock<Packages.PackageFactory>;
+    get packageFactory() : Packages.PackageFactory
+    {
+        return this.mockPackageFactory.target;
+    }
+
+    mockContext : TypeMoq.IMock<Context.Context>;
+    get context() : Context.Context
+    {
+        return this.mockContext.target;
+    }
+
+    constructor()
+    {
+        this.mockWrapper = TypeMoq.Mock.ofType<Wrappers.VSCode>();
+        this.mockBridge = TypeMoq.Mock.ofType<Async.EnvironmentBridge>();
+
+        this.mockWorkspaces = TypeMoq.Mock.ofType2(Autoproj.Workspaces, []);
+        this.mockTaskProvider = TypeMoq.Mock.ofType2(Tasks.Provider, [this.workspaces]);
+        this.mockPackageFactory = TypeMoq.Mock.ofType2(Packages.PackageFactory, [this.mockWrapper.target, this.taskProvider, this.mockBridge.target]);
+        this.mockContext = TypeMoq.Mock.ofType2(Context.Context, [this.mockWrapper.target, this.workspaces, this.packageFactory]);
+    }
+
+    setupWrapper(fn) {
+        return this.mockWrapper.setup(fn);
+    }
+
+    createWorkspace(...path : string[]) : string {
+        let wsPath = fullPath(...path);
+        createInstallationManifest([], ...path);
+        return wsPath;
+    }
+
+    createAndRegisterWorkspace(...path: string[]) {
+        let wsPath = this.createWorkspace(...path);
+        let mock = TypeMoq.Mock.ofType2(Autoproj.Workspace, [wsPath, false]);
+        this.workspaces.add(mock.target);
+        return { mock: mock, ws: mock.target };
+    }
+
+    addPackageToManifest(ws, path : string[], partialInfo: { [key: string]: any } = {}) : Autoproj.Package {
+        let partialVCS: { [key: string]: any } = partialInfo.vcs || {};
+        let result: Autoproj.Package = {
+            name: partialInfo.name || 'Unknown',
+            srcdir: fullPath(...path),
+            builddir: partialInfo.builddir || "Unknown",
+            prefix: partialInfo.prefix || "Unknown",
+            vcs: {
+                url: partialVCS.url || "Unknown",
+                type: partialVCS.type || "Unknown",
+                repository_id: partialVCS.repository_id || "Unknown"
+            },
+            type: partialInfo.type || "Unknown",
+            logdir: partialInfo.logdir || "Unknown",
+            dependencies: partialInfo.dependencies || "Unknown"
+        };
+
+        let manifestPath = Autoproj.installationManifestPath(ws.root)
+        let manifest = YAML.safeLoad(FS.readFileSync(manifestPath).toString());
+        manifest.push(result);
+        FS.writeFileSync(manifestPath, YAML.safeDump(manifest));
+        ws.reload();
+        return result;
+    }
+
+    async registerPackage(ws, path : string[], partialInfo: { [key: string]: any } = {}) : Promise<Packages.Package>
+    {
+        let full = fullPath(...path);
+        this.addPackageToManifest(ws, path, partialInfo)
+        this.workspaces.associateFolderToWorkspace(full, ws);
+        let folder: vscode.WorkspaceFolder = {
+            uri: vscode.Uri.file(full),
+            name: Path.basename(full),
+            index: 0
+        }
+        this.mockWrapper.setup(x => x.getWorkspaceFolder(full)).
+            returns(() => folder);
+        let pkg = await this.context.getPackageByPath(full);
+        if (pkg) {
+            return pkg;
+        }
+        else {
+            throw Error("failed to resolve package after registration");
+        }
+    }
+};

--- a/src/test/packages.test.ts
+++ b/src/test/packages.test.ts
@@ -261,6 +261,7 @@ describe("RockRubyPackage", function () {
         mockWrapper = TypeMoq.Mock.ofType<wrappers.VSCode>();
         subject = new packages.RockRubyPackage(
             mockBridge.object,
+            new autoproj.Workspace("path", false),
             autoprojMakePackage('package', 'Autobuild::Ruby', "/path/to/package"),
             mockContext.object, mockWrapper.object, mockTaskProvider.object);
     })
@@ -362,6 +363,7 @@ describe("RockCXXPackage", function () {
         mockTaskProvider = TypeMoq.Mock.ofType<tasks.Provider>();
         mockWrapper = TypeMoq.Mock.ofType<wrappers.VSCode>();
         subject = new packages.RockCXXPackage(
+            new autoproj.Workspace("path", false),
             autoprojMakePackage('package', 'Autobuild::CMake', "/path/to/package"),
             mockContext.object, mockWrapper.object, mockTaskProvider.object);
     })
@@ -518,6 +520,7 @@ describe("RockOrogenPackage", function () {
         mockWrapper = TypeMoq.Mock.ofType<wrappers.VSCode>();
         subject = new packages.RockOrogenPackage(
             mockBridge.object,
+            new autoproj.Workspace("path", false),
             autoprojMakePackage('package', 'Autobuild::Orogen', "/path/to/package"),
             mockContext.object, mockWrapper.object, mockTaskProvider.object);
     })

--- a/src/test/packages.test.ts
+++ b/src/test/packages.test.ts
@@ -38,104 +38,110 @@ describe("Type", function() {
 })
 
 describe("PackageFactory", function () {
+    let root: string;
+    let s: helpers.TestSetup;
     let subject: packages.PackageFactory;
-    let mockContext: TypeMoq.IMock<context.Context>;
-    let mockWorkspaces: TypeMoq.IMock<autoproj.Workspaces>;
-    let mockTaskProvider: TypeMoq.IMock<tasks.Provider>;
-    let mockWrapper: TypeMoq.IMock<wrappers.VSCode>;
     beforeEach(function () {
-        mockContext = TypeMoq.Mock.ofType<context.Context>();
-        mockWorkspaces = TypeMoq.Mock.ofType<autoproj.Workspaces>();
-        mockTaskProvider = TypeMoq.Mock.ofType<tasks.Provider>();
-        mockWrapper = TypeMoq.Mock.ofType<wrappers.VSCode>();
-        let mockBridge = TypeMoq.Mock.ofType<async.EnvironmentBridge>();
-        subject = new packages.PackageFactory(mockWrapper.object, mockTaskProvider.object, mockBridge.object);
+        root = helpers.init();
+        s = new helpers.TestSetup();
+        subject = s.packageFactory;
     })
-    it("creates a ConfigPackage", async function () {
+    it("creates a ConfigPackage for a package set", async function () {
         let path = '/path/to/package';
-        mockContext.setup(x => x.workspaces).returns(() => mockWorkspaces.object);
-        mockWorkspaces.setup(x => x.isConfig(path)).returns(() => true)
-        let aPackage = await subject.createPackage(path, mockContext.object);
-        await assertThrowsAsync(async () => {
-            await aPackage.build();
-        }, /configuration package/);
+        s.mockWorkspaces.setup(x => x.isConfig(path)).returns(() => true)
+        let aPackage = await subject.createPackage(path, s.context);
+        assert(aPackage instanceof packages.ConfigPackage);
     })
     it("creates an InvalidPackage if package is not in vscode ws", async function () {
         let path = '/path/to/package';
-        mockContext.setup(x => x.workspaces).returns(() => mockWorkspaces.object);
-        mockWorkspaces.setup(x => x.isConfig(path)).returns(() => false)
-        mockWrapper.setup(x => x.getWorkspaceFolder(path)).
+        s.mockWrapper.setup(x => x.getWorkspaceFolder(path)).
             returns(() => undefined);
-        let aPackage = await subject.createPackage(path, mockContext.object);
+        let aPackage = await subject.createPackage(path, s.context);
         assert.equal(aPackage.name, '(Invalid package)');
     })
     describe("the package is neither invalid nor a configuration", function () {
-        let path = '/path/to/package';
-        let folder: vscode.WorkspaceFolder = {
-            uri: vscode.Uri.file(path),
-            name: 'package',
-            index: 0
-        }
-        beforeEach(function () {
-            mockContext.setup(x => x.workspaces).returns(() => mockWorkspaces.object);
-            mockWorkspaces.setup(x => x.isConfig(path)).returns(() => false);
-            mockWrapper.setup(x => x.getWorkspaceFolder(path)).
-                returns(() => folder);
+        let path;
+        let folder: vscode.WorkspaceFolder;
+        beforeEach(function() {
+            path = helpers.mkdir('package');
+            helpers.registerDir('.vscode');
+            folder = {
+                uri: vscode.Uri.file(path),
+                name: 'package',
+                index: 0
+            }
+            s.mockWrapper.setup(x => x.getWorkspaceFolder(path)).
+                returns(() => folder)
         })
         it("creates a ForeignPackage if the package is not in an autoproj ws", async function () {
-            mockContext.setup(x => x.getWorkspaceByPath(TypeMoq.It.isAny())).
-                returns(() => undefined);
+            s.mockContext.
+                setup(x => x.getWorkspaceByPath(path)).returns(() => undefined)
 
-            let aPackage = await subject.createPackage(path, mockContext.object);
-            await assertThrowsAsync(async () => {
-                await aPackage.build();
-            }, /not part of an autoproj workspace/);
+            let aPackage = await subject.createPackage(path, s.context);
+            assert(aPackage instanceof packages.ForeignPackage);
         })
         describe("the package is in an autoproj workspace", function () {
-            let mockWs: TypeMoq.IMock<autoproj.Workspace>;
-            beforeEach(function () {
-                mockWs = TypeMoq.Mock.ofType<autoproj.Workspace>();
-                mockContext.setup(x => x.getWorkspaceByPath(path)).
-                    returns(() => mockWs.object)
+            let mockWS: TypeMoq.IMock<autoproj.Workspace>;
+            let ws: autoproj.Workspace;
+            let emptyInfo: autoproj.WorkspaceInfo;
+            const rubyType = packages.Type.fromType(packages.TypeList.RUBY)
+            const otherType = packages.Type.fromType(packages.TypeList.OTHER)
+            beforeEach(async function () {
+                let created = s.createAndRegisterWorkspace('test');
+                mockWS = created.mock;
+                ws = created.ws;
+                s.mockContext.setup(x => x.getWorkspaceByPath(path)).
+                    returns((path) => ws);
+                emptyInfo = new autoproj.WorkspaceInfo(ws.root);
+                mockWS.setup(x => x.envsh()).returns(() => Promise.resolve(emptyInfo));
             })
-            it("returns the type set by the user", async function () {
-                mockContext.setup(x => x.getWorkspaceByPath(path)).
-                    returns(() => undefined);
-                mockContext.setup(x => x.getPackageType(path)).
+            it("returns the type set by the user even if there is no data in the workspace", async function () {
+                s.mockContext.setup(x => x.getPackageType(path)).
                     returns(() => packages.Type.fromType(packages.TypeList.RUBY));
-                let aPackage = await subject.createPackage(path, mockContext.object);
+                let aPackage = await subject.createPackage(path, s.context);
                 assert.deepEqual(aPackage.type, packages.Type.fromType(packages.TypeList.RUBY));
             })
-            it("returns an OTHER package if the manifest could not be loaded", async function () {
-                mockContext.setup(x => x.getPackageType(path)).
-                    returns(() => undefined);
-                mockWs.setup(x => x.info()).returns(() => Promise.reject(""));
-                let aPackage = await subject.createPackage(path, mockContext.object);
-                assert.deepEqual(aPackage.type, packages.Type.fromType(packages.TypeList.OTHER));
+            it("returns the type set by the user, overriding what is in the workspace", async function () {
+                s.addPackageToManifest(ws, ['package'], { type: 'Autobuild::CMake' });
+                s.context.setPackageType(path, rubyType);
+                let aPackage = await subject.createPackage(path, s.context);
+                assert.deepEqual(aPackage.type, rubyType);
+            })
+            it("sets a null package info if the workspace doesn't have one", async function () {
+                s.addPackageToManifest(ws, ['package'], { type: 'Autobuild::CMake' });
+                mockWS.setup(x => x.info()).returns(() => Promise.resolve(emptyInfo));
+                s.context.setPackageType(path, rubyType);
+                let aPackage = await subject.createPackage(path, s.context);
+                assert.equal("Unknown", (aPackage as packages.RockPackage).info.type);
+            })
+            it("returns an OTHER package if the manifest has no type info and the user has not set a type", async function () {
+                mockWS.setup(x => x.info()).returns(() => Promise.resolve(emptyInfo));
+                let aPackage = await subject.createPackage(path, s.context);
+                assert.deepEqual(aPackage.type, otherType);
             })
             it("returns the package type defined in the manifest", async function () {
-                let wsInfo = new autoproj.WorkspaceInfo('/path/to');
-                let mockPackage = TypeMoq.Mock.ofType<autoproj.Package>();
-                mockPackage.setup(x => x.type).returns(() => "Autobuild::CMake");
-                mockPackage.setup((x: any) => x.then).returns(() => undefined);
-                wsInfo.packages.set('/path/to/package', mockPackage.object);
-
-                mockContext.setup(x => x.getPackageType(path)).
-                    returns(() => undefined);
-                mockWs.setup(x => x.root).returns(() => '/path/to');
-                mockWs.setup(x => x.info()).returns(() => Promise.resolve(wsInfo));
-                let aPackage = await subject.createPackage(path, mockContext.object);
-                assert.deepEqual(aPackage.type, packages.Type.fromType(packages.TypeList.CXX));
+                s.addPackageToManifest(ws, ['package'], { type: 'Autobuild::Ruby' });
+                let aPackage = await subject.createPackage(path, s.context);
+                assert.deepEqual(aPackage.type, rubyType);
             })
-            it("returns OTHER if the package is not in the manifest", async function () {
-                let wsInfo = new autoproj.WorkspaceInfo('/path/to');
-                mockContext.setup(x => x.getPackageType(path)).
-                    returns(() => undefined);
-                mockWs.setup(x => x.root).returns(() => '/path/to');
-                mockWs.setup(x => x.info()).returns(() => Promise.resolve(wsInfo));
-                mockWs.setup(x => x.envsh()).returns(() => Promise.resolve(wsInfo));
-                let aPackage = await subject.createPackage(path, mockContext.object);
-                assert.deepEqual(aPackage.type, packages.Type.fromType(packages.TypeList.OTHER));
+            it("embeds the containing workspace in the package objects", async function () {
+                s.addPackageToManifest(ws, ['package'], { type: 'Autobuild::Ruby' });
+                let aPackage = await subject.createPackage(path, s.context);
+                assert.equal((aPackage as packages.RockPackage).ws, ws);
+            })
+            it("attempts to regenerate the manifest if the package is not present in it", async function() {
+                mockWS.setup(x => x.envsh()).
+                    returns(() => {
+                        s.addPackageToManifest(ws, ['package'], { type: 'Autobuild::Ruby' })
+                        return ws.reload();
+                    });
+                let aPackage = await subject.createPackage(path, s.context);
+                assert.deepEqual(aPackage.type, rubyType);
+            })
+            it("returns OTHER if the package is not in the manifest even after reloading", async function () {
+                mockWS.setup(x => x.envsh()).returns(() => Promise.resolve(emptyInfo));
+                let aPackage = await subject.createPackage(path, s.context);
+                assert.deepEqual(aPackage.type, otherType);
             })
         })
     })

--- a/stubs/gdb
+++ b/stubs/gdb
@@ -1,0 +1,3 @@
+#! /bin/sh
+
+exec "$VSCODE_ROCK_AUTOPROJ_PATH" exec "$VSCODE_ROCK_AUTOPROJ_DEBUGGER" "$@"


### PR DESCRIPTION
This handles C++ and Ruby debug configurations in `launch.json` to allow running them within a Rock workspace transparently.

Behind the scenes, the extension now starts all the debugged processes using the workspace's environment (using `autoproj exec`)

In addition, the extension provides four variable expansions that can be used within `launch.json` in the `program` and `cwd` fields of the debug configurations:
- `${rock:srcDir}` expands to the package's source directory
- `${rock:buildDir}` expands to the package's build directory
- `${rock:prefixDir}` expands to the package's prefix directory
- `${rock:which:_cmd_}` expands to the result of `autoproj which _cmd_` as run within the workspace, i.e. solves the full path to `_cmd_` with the `PATH` of the workspace.

For instance, a Ruby `rake test` configuration would be:

~~~
{
"name": "rock - Run test suite (Rake)",
"type": "Ruby",
"request": "launch",
"cwd": "${workspaceRoot}",
"program": "${rock:which:rake}",
"args": ["test"]
}
~~~

a C++ `Run Rock's default test suite` would be:

~~~
        {
            "name": "(gdb) Launch",
            "type": "cppdbg",
            "request": "launch",
            "program": "${rock:buildDir}/test/suite",
            "cwd": "${rock:buildDir}",
            "args": [],
            "stopAtEntry": false,
            "environment": [],
            "externalConsole": true,
            "MIMode": "gdb",
            "setupCommands": [
                {
                    "description": "Enable pretty-printing for gdb",
                    "text": "-enable-pretty-printing",
                    "ignoreFailures": true
                }
            ]
        }
~~~
