### PR TITLE
Add launch entry

### DIFF
--- a/package.json
+++ b/package.json
@@ -140,6 +140,11 @@
                 "title": "Update package info",
                 "category": "rock",
                 "command": "rock.updatePackageInfo"
+            },
+            {
+                "title": "Add launch config",
+                "category": "rock",
+                "command": "rock.addLaunchConfig"
             }
         ],
         "languages": [

--- a/src/async.ts
+++ b/src/async.ts
@@ -7,7 +7,6 @@ import * as path from 'path';
 import * as autoproj from './autoproj';
 import { SpawnOptions } from 'child_process';
 
-const ENV_DUMP_SCRIPT = "require 'json'; puts ENV.to_hash.to_json";
 const OROGEN_DESCRIBE_SCRIPT = `
 require 'orogen'
 require 'json'
@@ -90,22 +89,6 @@ export class EnvironmentBridge
                 },
                 err => {
                     reject(new Error("Could not load orogen project: " + err.message));
-                }
-            )
-        });
-        return promise;
-    }
-
-    async env(root: string): Promise<{ [key: string]: string }>
-    {
-        let env = jsonFromRubyScript(root, ENV_DUMP_SCRIPT);
-        let promise = new Promise<{ [key: string]: string }>((resolve, reject) => {
-            env.then(
-                result => {
-                    resolve(result);
-                },
-                err => {
-                    reject(new Error("Could not load environment: " + err.message));
                 }
             )
         });

--- a/src/debug.ts
+++ b/src/debug.ts
@@ -44,7 +44,7 @@ export class PreLaunchTaskProvider implements vscode.TaskProvider
     {
         let ws = context.workspaces.folderToWorkspace.get(pkg.path)
         if (!ws) {
-            throw new Error("package not in a workspace");
+            return;
         }
 
         if (pkg.type.id === packages.TypeList.OROGEN.id)

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -64,9 +64,9 @@ export function activate(extensionContext: vscode.ExtensionContext) {
         new packages.PackageFactory(vscodeWrapper, taskProvider, bridge));
 
     let statusBar = new status.StatusBar(extensionContext, rockContext);
-    let rockCommands = new commands.Commands(rockContext, vscodeWrapper);
-    let preLaunchTaskProvider = new debug.PreLaunchTaskProvider(rockContext, vscodeWrapper);
     let configManager = new config.ConfigManager(workspaces);
+    let rockCommands = new commands.Commands(rockContext, vscodeWrapper, configManager);
+    let preLaunchTaskProvider = new debug.PreLaunchTaskProvider(rockContext, vscodeWrapper);
 
     extensionContext.subscriptions.push(
         vscode.workspace.registerTaskProvider('autoproj', taskProvider));

--- a/src/packages.ts
+++ b/src/packages.ts
@@ -228,6 +228,7 @@ export interface Package
     build(): Promise<void>
     pickTarget(): Promise<void>
     pickType(): Promise<void>
+    customDebugConfiguration(): Promise<vscode.DebugConfiguration | undefined>
 }
 
 abstract class GenericPackage implements Package
@@ -241,6 +242,7 @@ abstract class GenericPackage implements Package
     abstract debug(): Promise<void>
     abstract build(): Promise<void>
     abstract pickTarget(): Promise<void>
+    abstract customDebugConfiguration(): Promise<vscode.DebugConfiguration | undefined>
 
     protected readonly _context: context.Context;
     constructor(context: context.Context)
@@ -346,6 +348,11 @@ export class InvalidPackage implements Package
         throw new Error("Select a valid package before picking the package type")
     }
 
+    async customDebugConfiguration(): Promise<vscode.DebugConfiguration | undefined>
+    {
+        throw new Error("Select a valid package before trying to create a debug configuration");
+    }
+
     get type()
     {
         return Type.invalid();
@@ -384,6 +391,11 @@ export class ConfigPackage implements Package
     async pickType(): Promise<void>
     {
         throw new Error("Setting a type for a configuration package is not possible");
+    }
+
+    async customDebugConfiguration(): Promise<vscode.DebugConfiguration | undefined>
+    {
+        throw new Error("Debug configurations are not available for configuration packages");
     }
 
     get type()
@@ -429,6 +441,11 @@ export class ForeignPackage extends GenericPackage
     {
         throw new Error("Setting a debugging target for a package that is not part of an autoproj workspace is not available");
     }
+
+    async customDebugConfiguration(): Promise<vscode.DebugConfiguration | undefined>
+    {
+        throw new Error("Debug configurations are not available for external packages");
+    }
 }
 
 export class RockRubyPackage extends RockPackageWithTargetPicker
@@ -462,6 +479,27 @@ export class RockRubyPackage extends RockPackageWithTargetPicker
                     };
                     return options;
                 });
+    }
+
+    async customDebugConfiguration(): Promise<vscode.DebugConfiguration | undefined>
+    {
+        const options: vscode.OpenDialogOptions = {
+            canSelectMany: false,
+            canSelectFiles: true,
+            canSelectFolders: false,
+            defaultUri: vscode.Uri.file(this.path),
+            openLabel: "Debug file"
+        };
+        const targetUri = await this._vscode.showOpenDialog(options);
+        if (targetUri) {
+            const debugConfig: vscode.DebugConfiguration = {
+                type: "Ruby",
+                name: relative(this.path, targetUri[0].fsPath),
+                request: "launch",
+                program: targetUri[0].fsPath
+            };
+            return debugConfig;
+        }
     }
     get type() { return Type.fromType(TypeList.RUBY); }
 }
@@ -580,6 +618,28 @@ export class RockCXXPackage extends RockPackage
         };
         return options;
     }
+
+    async customDebugConfiguration(): Promise<vscode.DebugConfiguration | undefined>
+    {
+        const executable = await this.pickExecutable();
+        if (executable) {
+            const debugConfig: vscode.DebugConfiguration = {
+                type: "cppdbg",
+                name: relative(this.path, executable),
+                request: "launch",
+                program: executable,
+                MIMode: "gdb",
+                setupCommands: [
+                    {
+                        description: "Enable pretty-printing for gdb",
+                        text: "-enable-pretty-printing",
+                        ignoreFailures: false
+                    }
+                ]
+            };
+            return debugConfig;
+        }
+    }
     get type() { return Type.fromType(TypeList.CXX); }
 }
 
@@ -667,6 +727,10 @@ export class RockOrogenPackage extends RockPackage
             throw err;
         }
     }
+    async customDebugConfiguration(): Promise<vscode.DebugConfiguration | undefined>
+    {
+        throw new Error("Not supported yet");
+    }
     get type() { return Type.fromType(TypeList.OROGEN); }
 }
 
@@ -706,6 +770,9 @@ export class RockOtherPackage extends GenericPackage
     {
         throw new Error("Set the package type before trying to debug this package");
     }
-
+    async customDebugConfiguration(): Promise<vscode.DebugConfiguration | undefined>
+    {
+        throw new Error("Set the package type before creating a debug configuration");
+    }
     get type() { return Type.fromType(TypeList.OTHER); }
 }

--- a/src/packages.ts
+++ b/src/packages.ts
@@ -465,20 +465,16 @@ export class RockRubyPackage extends RockPackageWithTargetPicker
     async debugConfiguration(): Promise<vscode.DebugConfiguration>
     {
         const debugTarget = this.debugTarget as debug.Target;
-        return this._bridge.env(this.path).
-            then(result => {
-                    let userConf = this._context.debugConfig(this.path);
-                    const options: vscode.DebugConfiguration = {
-                        type: "Ruby",
-                        name: "rock debug",
-                        request: "launch",
-                        program: debugTarget.path,
-                        env: result,
-                        cwd: userConf.cwd,
-                        args: userConf.args
-                    };
-                    return options;
-                });
+        let userConf = this._context.debugConfig(this.path);
+        const options: vscode.DebugConfiguration = {
+            type: "Ruby",
+            name: "rock debug",
+            request: "launch",
+            program: debugTarget.path,
+            cwd: userConf.cwd,
+            args: userConf.args
+        };
+        return options;
     }
 
     async customDebugConfiguration(): Promise<vscode.DebugConfiguration | undefined>

--- a/src/packages.ts
+++ b/src/packages.ts
@@ -486,7 +486,13 @@ export class RockCXXPackage extends RockPackageWithTargetPicker
         const files = fs.readdirSync(path);
         for (let file of files) {
             const fullPath = joinpath(path, file);
-            const stat = fs.statSync(fullPath);
+            let stat: fs.Stats;
+            try {
+                stat = fs.statSync(fullPath);
+            }
+            catch (e) {
+                continue; // ignore files that can't be stat'ed (i.e broken symlinks)
+            }
             if (stat.isDirectory()) {
                 if (!EXCLUDED_DIRS.some(filter => filter.test(file))) {
                     executables = executables.concat(await this.listExecutables(fullPath));

--- a/src/test/debug.test.ts
+++ b/src/test/debug.test.ts
@@ -105,13 +105,11 @@ describe("Pre Launch Task Provider", function () {
     });
 
     describe("ConfigurationProvider", function() {
-        let root: string;
         let s: helpers.TestSetup;
         let subject: debug.ConfigurationProvider;
         let mock;
         let ws;
         beforeEach(function() {
-            root = helpers.init();
             s = new helpers.TestSetup();
             subject = new debug.ConfigurationProvider(s.context);
             let result = s.createAndRegisterWorkspace('test');

--- a/src/test/packages.test.ts
+++ b/src/test/packages.test.ts
@@ -318,17 +318,6 @@ describe("RockRubyPackage", function () {
                 await subject.debug();
             }, /Select a debugging target/);
         })
-        it("throws if environment cannot be loaded", async function () {
-            let error = new Error("test");
-            const target = new debug.Target('package', '/path/to/package/build/test');            
-            mockBridge.setup(x => x.env(subject.path)).returns(() => Promise.reject(error));
-            mockContext.setup(x => x.getDebuggingTarget(subject.path)).
-                returns(() => target);
-
-            await assertThrowsAsync(async () => {
-                await subject.debug();
-            }, /test/);
-        })
         it("starts a ruby debugging session", async function () {
             const target = new debug.Target('package', '/path/to/package/build/test');
             let userConf: context.RockDebugConfig = {
@@ -341,10 +330,6 @@ describe("RockRubyPackage", function () {
                 }
             }
             const type = packages.TypeList.RUBY;
-            let env = {
-                key: 'KEY',
-                value: 'VALUE'
-            }
             const options = {
                 type: "Ruby",
                 name: "rock debug",
@@ -352,10 +337,7 @@ describe("RockRubyPackage", function () {
                 program: target.path,
                 cwd: userConf.cwd,
                 args: userConf.args,
-                env: env
             };
-
-            mockBridge.setup(x => x.env(subject.path)).returns(() => Promise.resolve(env));
             mockContext.setup(x => x.debugConfig(subject.path)).returns(() => userConf);
             mockContext.setup(x => x.getDebuggingTarget(subject.path)).
                 returns(() => target);

--- a/src/test/packages.test.ts
+++ b/src/test/packages.test.ts
@@ -47,6 +47,9 @@ describe("PackageFactory", function () {
         s = new helpers.TestSetup();
         subject = s.packageFactory;
     })
+    afterEach(function () {
+        helpers.clear();
+    })
     it("creates a ConfigPackage for a package set", async function () {
         let path = '/path/to/package';
         s.mockWorkspaces.setup(x => x.isConfig(path)).returns(() => true)
@@ -65,7 +68,8 @@ describe("PackageFactory", function () {
         let folder: vscode.WorkspaceFolder;
         beforeEach(function() {
             path = helpers.mkdir('package');
-            helpers.registerDir('.vscode');
+            helpers.registerDir('package', '.vscode');
+            helpers.registerFile('package', '.vscode', 'rock.json')
             folder = {
                 uri: vscode.Uri.file(path),
                 name: 'package',


### PR DESCRIPTION
Known issue: VSCode doesn't watch the creation of launch.json so, after adding the entry, the user has to restart otherwise it won't show in the debug viewlet.. We have to find a workaround for that...