### PR TITLE
disable coverage by default

### DIFF
--- a/coverconfig.json
+++ b/coverconfig.json
@@ -1,5 +1,5 @@
 {
-    "enabled": true,
+    "enabled": false,
     "relativeSourcePath": "../src/",
     "relativeCoverageDir": "../../coverage",
     "ignorePatterns": ["**/test/**"],


### PR DESCRIPTION
Code coverage breaks debugging (breakpoints)