### PR TITLE
add a build (nodeps) task

### DIFF
--- a/src/tasks.ts
+++ b/src/tasks.ts
@@ -13,6 +13,7 @@ export class AutoprojProvider implements vscode.TaskProvider
     workspaces : autoproj.Workspaces;
 
     private _buildTasks: Map<string, vscode.Task>;
+    private _nodepsBuildTasks: Map<string, vscode.Task>;
     private _forceBuildTasks: Map<string, vscode.Task>;
     private _updateTasks: Map<string, vscode.Task>;
     private _checkoutTasks: Map<string, vscode.Task>;
@@ -82,6 +83,12 @@ export class AutoprojProvider implements vscode.TaskProvider
             [...args, folder])
     }
 
+    private createPackageNodepsBuildTask(name, ws, folder, defs = {}, args : string[] = []) {
+        return this.createPackageBuildTask(name, ws, folder,
+            { mode: 'build-no-deps', ...defs },
+            ['--deps=f', ...args]);
+    }
+
     private createPackageForceBuildTask(name, ws, folder, defs = {}, args : string[] = []) {
         return this.createPackageBuildTask(name, ws, folder,
             { mode: 'force-build', ...defs },
@@ -122,6 +129,11 @@ export class AutoprojProvider implements vscode.TaskProvider
         return this.getCache(this._forceBuildTasks, path);
     }
 
+    public nodepsBuildTask(path: string): vscode.Task
+    {
+        return this.getCache(this._nodepsBuildTasks, path);
+    }
+
     public updateTask(path: string): vscode.Task
     {
         return this.getCache(this._updateTasks, path);
@@ -154,6 +166,7 @@ export class AutoprojProvider implements vscode.TaskProvider
         this._allTasks = [];
 
         this._buildTasks = new Map<string, vscode.Task>();
+        this._nodepsBuildTasks = new Map<string, vscode.Task>();
         this._forceBuildTasks = new Map<string, vscode.Task>();
         this._updateTasks = new Map<string, vscode.Task>();
         this._checkoutTasks = new Map<string, vscode.Task>();
@@ -180,8 +193,10 @@ export class AutoprojProvider implements vscode.TaskProvider
                 this._buildTasks);
             this.addTask(folder, this.createPackageCheckoutTask(`${ws.name}: Checkout ${relative}`, ws, folder),
                 this._checkoutTasks);
-            this.addTask(folder, this.createPackageForceBuildTask(`${ws.name}: Force Build ${relative}`, ws, folder),
+            this.addTask(folder, this.createPackageForceBuildTask(`${ws.name}: Force Build ${relative} (nodeps)`, ws, folder),
                 this._forceBuildTasks);
+            this.addTask(folder, this.createPackageNodepsBuildTask(`${ws.name}: Build ${relative} (nodeps)`, ws, folder),
+                this._nodepsBuildTasks);
             this.addTask(folder, this.createPackageUpdateTask(`${ws.name}: Update ${relative}`, ws, folder),
                 this._updateTasks);
         })

--- a/test/tasks.test.ts
+++ b/test/tasks.test.ts
@@ -44,6 +44,12 @@ describe("Task provider", function () {
         let args = ['build', '--tool', '--force', '--deps=f', '--no-confirm', path];
         assertTask(task, process, args);
     }
+    function assertNodepsBuildTask(task: vscode.Task, path: string)
+    {
+        let process = autoprojExePath(path);
+        let args = ['build', '--tool', '--deps=f', path];
+        assertTask(task, process, args);
+    }
     function assertUpdateTask(task: vscode.Task, path: string, isPackage = true)
     {
         let process = autoprojExePath(path);
@@ -75,6 +81,10 @@ describe("Task provider", function () {
         let buildTask = subject.buildTask(path);
         assert.notEqual(buildTask, undefined);
         assertBuildTask(buildTask, path);
+
+        let nodepsBuildTask = subject.nodepsBuildTask(path);
+        assert.notEqual(nodepsBuildTask, undefined);
+        assertNodepsBuildTask(nodepsBuildTask, path);
 
         let forceBuildTask = subject.forceBuildTask(path);
         assert.notEqual(forceBuildTask, undefined);
@@ -142,7 +152,7 @@ describe("Task provider", function () {
         })
         it("is initalized with all tasks", function () {
             let tasks = subject.provideTasks(null);
-            assert.equal(tasks.length, 22);
+            assert.equal(tasks.length, 25);
 
             assertAllTasks(a);
             assertAllTasks(b);
@@ -168,7 +178,7 @@ describe("Task provider", function () {
             subject.reloadTasks();
 
             let tasks = subject.provideTasks(null);
-            assert.equal(tasks.length, 9);
+            assert.equal(tasks.length, 10);
             assertAllTasks(a);
         })
     });


### PR DESCRIPTION
This is really useful when working on e.g. base/types for a
particular package, and one doesn't want to rebuild the whole
stack each time.

And mark the force build task as (nodeps) since it has --deps=f