### PR TITLE
Improve multi workspace handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,15 +41,17 @@ run `autoproj osdeps`.
 - rock.vscode.gems
 ~~~
 
-## Management of Autoproj Workspaces
+## Workflow
 
-The extension will start providing commands and support for a given Rock
-workspace as soon as at least one package from this workspace is opened in
-VSCode (via the "Add Folder to Workspace" command).
+The extension does not provide support to bootstrap a workspace. It only
+works with an existing workspace.
 
-Once there is such a folder opened in VSCode, other packages from the same
-workspace can easily be added with the `Rock: add package to workspace` command
-provided by this extension.
+Open an Autoproj workspace using the `Rock: Add Workspace` command. This will
+add the workspace's `autoproj/` folder to your VSCode environment. From there
+on, add the packages you want to work on using the `Rock: Add Package to Workspace`
+command.
+
+
 
 ## Important Note about `env.sh`
 
@@ -57,6 +59,10 @@ provided by this extension.
 generates its own environment. Loading env.sh is even harmful as it would break
 if you were opening packages and programs from a different workspace than the one
 you loaded the env.sh from.
+
+Click on the image below for a demo video:
+
+[![Basic folder workflow](https://img.youtube.com/vi/TxxOOZdDW8c/0.jpg)](https://youtu.be/TxxOOZdDW8c)
 
 ## Autoproj Integration
 
@@ -82,7 +88,7 @@ And the `Run Build Task` picker:
 gives a convenient way to run the same task over and over again.
 
 **Important** if you create a new package, you must add it to the `layout`
-section of `autoproj/manifest` and run the `rock - Update package info` 
+section of `autoproj/manifest` and run the `rock - Update package info`
 command before the extension tools can be used for it.
 
 ## C++ Packages

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,13 +1,13 @@
 {
     "name": "rock",
-    "version": "0.3.0",
+    "version": "0.4.0",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {
         "@types/js-yaml": {
-            "version": "3.11.2",
-            "resolved": "https://registry.npmjs.org/@types/js-yaml/-/js-yaml-3.11.2.tgz",
-            "integrity": "sha512-JRDtMPEqXrzfuYAdqbxLot1GvAr/QvicIZAnOAigZaj8xVMhuSJTg/xsv9E1TvyL+wujYhRLx9ZsQ0oFOSmwyA==",
+            "version": "3.12.0",
+            "resolved": "https://registry.npmjs.org/@types/js-yaml/-/js-yaml-3.12.0.tgz",
+            "integrity": "sha512-UGEe/6RsNAxgWdknhzFZbCxuYc5I7b/YEKlfKbo+76SM8CJzGs7XKCj7zyugXViRbKYpXhSXhCYVQZL5tmDbpQ==",
             "dev": true
         },
         "@types/node": {
@@ -22,7 +22,7 @@
             "integrity": "sha512-Mi6YZ2ABnnGGFMuiBDP0a8s1ZDCDNHqP97UH8TyDmCWuGGavpsFMfJnAMYaaqmDlSCOCNbVLHBrSDEOpx/oLhw==",
             "dev": true,
             "requires": {
-                "should": "13.2.3"
+                "should": "*"
             }
         },
         "abbrev": {
@@ -36,10 +36,10 @@
             "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
             "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
             "requires": {
-                "co": "4.6.0",
-                "fast-deep-equal": "1.1.0",
-                "fast-json-stable-stringify": "2.0.0",
-                "json-schema-traverse": "0.3.1"
+                "co": "^4.6.0",
+                "fast-deep-equal": "^1.0.0",
+                "fast-json-stable-stringify": "^2.0.0",
+                "json-schema-traverse": "^0.3.0"
             }
         },
         "align-text": {
@@ -48,9 +48,9 @@
             "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
             "dev": true,
             "requires": {
-                "kind-of": "3.2.2",
-                "longest": "1.0.1",
-                "repeat-string": "1.6.1"
+                "kind-of": "^3.0.2",
+                "longest": "^1.0.1",
+                "repeat-string": "^1.5.2"
             }
         },
         "amdefine": {
@@ -65,7 +65,7 @@
             "integrity": "sha512-SFKX67auSNoVR38N3L+nvsPjOE0bybKTYbkf5tRvushrAPQ9V75huw0ZxBkKVeRU9kqH3d6HA4xTckbwZ4ixmA==",
             "dev": true,
             "requires": {
-                "ansi-wrap": "0.1.0"
+                "ansi-wrap": "^0.1.0"
             }
         },
         "ansi-cyan": {
@@ -124,7 +124,7 @@
             "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.9.tgz",
             "integrity": "sha1-c9g7wmP4bpf4zE9rrhsOkKfSLIY=",
             "requires": {
-                "sprintf-js": "1.0.3"
+                "sprintf-js": "~1.0.2"
             }
         },
         "arr-diff": {
@@ -180,7 +180,7 @@
             "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
             "dev": true,
             "requires": {
-                "array-uniq": "1.0.3"
+                "array-uniq": "^1.0.1"
             }
         },
         "array-uniq": {
@@ -258,13 +258,13 @@
             "integrity": "sha512-5T6P4xPgpp0YDFvSWwEZ4NoE3aM4QBQXDzmVbraCkFj8zHM+mba8SyqB5DbZWyR7mYHo6Y7BdQo3MoA4m0TeQg==",
             "dev": true,
             "requires": {
-                "cache-base": "1.0.1",
-                "class-utils": "0.3.6",
-                "component-emitter": "1.2.1",
-                "define-property": "1.0.0",
-                "isobject": "3.0.1",
-                "mixin-deep": "1.3.1",
-                "pascalcase": "0.1.1"
+                "cache-base": "^1.0.1",
+                "class-utils": "^0.3.5",
+                "component-emitter": "^1.2.1",
+                "define-property": "^1.0.0",
+                "isobject": "^3.0.1",
+                "mixin-deep": "^1.2.0",
+                "pascalcase": "^0.1.1"
             },
             "dependencies": {
                 "define-property": {
@@ -273,7 +273,7 @@
                     "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
                     "dev": true,
                     "requires": {
-                        "is-descriptor": "1.0.2"
+                        "is-descriptor": "^1.0.0"
                     }
                 },
                 "isobject": {
@@ -295,7 +295,7 @@
             "integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
             "optional": true,
             "requires": {
-                "tweetnacl": "0.14.5"
+                "tweetnacl": "^0.14.3"
             }
         },
         "beeper": {
@@ -310,7 +310,7 @@
             "integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
             "dev": true,
             "requires": {
-                "inherits": "2.0.3"
+                "inherits": "~2.0.0"
             }
         },
         "bluebird": {
@@ -325,7 +325,7 @@
             "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
             "dev": true,
             "requires": {
-                "hoek": "2.16.3"
+                "hoek": "2.x.x"
             }
         },
         "brace-expansion": {
@@ -334,7 +334,7 @@
             "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
             "dev": true,
             "requires": {
-                "balanced-match": "1.0.0",
+                "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
             }
         },
@@ -344,9 +344,9 @@
             "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
             "dev": true,
             "requires": {
-                "expand-range": "1.8.2",
-                "preserve": "0.2.0",
-                "repeat-element": "1.1.2"
+                "expand-range": "^1.8.1",
+                "preserve": "^0.2.0",
+                "repeat-element": "^1.1.2"
             }
         },
         "browser-stdout": {
@@ -379,15 +379,15 @@
             "integrity": "sha512-AKcdTnFSWATd5/GCPRxr2ChwIJ85CeyrEyjRHlKxQ56d4XJMGym0uAiKn0xbLOGOl3+yRpOTi484dVCEc5AUzQ==",
             "dev": true,
             "requires": {
-                "collection-visit": "1.0.0",
-                "component-emitter": "1.2.1",
-                "get-value": "2.0.6",
-                "has-value": "1.0.0",
-                "isobject": "3.0.1",
-                "set-value": "2.0.0",
-                "to-object-path": "0.3.0",
-                "union-value": "1.0.0",
-                "unset-value": "1.0.0"
+                "collection-visit": "^1.0.0",
+                "component-emitter": "^1.2.1",
+                "get-value": "^2.0.6",
+                "has-value": "^1.0.0",
+                "isobject": "^3.0.1",
+                "set-value": "^2.0.0",
+                "to-object-path": "^0.3.0",
+                "union-value": "^1.0.0",
+                "unset-value": "^1.0.0"
             },
             "dependencies": {
                 "isobject": {
@@ -417,8 +417,8 @@
             "integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
             "dev": true,
             "requires": {
-                "camelcase": "2.1.1",
-                "map-obj": "1.0.1"
+                "camelcase": "^2.0.0",
+                "map-obj": "^1.0.0"
             },
             "dependencies": {
                 "camelcase": {
@@ -442,8 +442,8 @@
             "dev": true,
             "optional": true,
             "requires": {
-                "align-text": "0.1.4",
-                "lazy-cache": "1.0.4"
+                "align-text": "^0.1.3",
+                "lazy-cache": "^1.0.3"
             }
         },
         "chalk": {
@@ -452,11 +452,11 @@
             "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
             "dev": true,
             "requires": {
-                "ansi-styles": "2.2.1",
-                "escape-string-regexp": "1.0.5",
-                "has-ansi": "2.0.0",
-                "strip-ansi": "3.0.1",
-                "supports-color": "2.0.0"
+                "ansi-styles": "^2.2.1",
+                "escape-string-regexp": "^1.0.2",
+                "has-ansi": "^2.0.0",
+                "strip-ansi": "^3.0.0",
+                "supports-color": "^2.0.0"
             }
         },
         "circular-json": {
@@ -471,10 +471,10 @@
             "integrity": "sha512-qOhPa/Fj7s6TY8H8esGu5QNpMMQxz79h+urzrNYN6mn+9BnxlDGf5QZ+XeCDsxSjPqsSR56XOZOJmpeurnLMeg==",
             "dev": true,
             "requires": {
-                "arr-union": "3.1.0",
-                "define-property": "0.2.5",
-                "isobject": "3.0.1",
-                "static-extend": "0.1.2"
+                "arr-union": "^3.1.0",
+                "define-property": "^0.2.5",
+                "isobject": "^3.0.0",
+                "static-extend": "^0.1.1"
             },
             "dependencies": {
                 "define-property": {
@@ -483,7 +483,7 @@
                     "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
                     "dev": true,
                     "requires": {
-                        "is-descriptor": "0.1.6"
+                        "is-descriptor": "^0.1.0"
                     }
                 },
                 "is-accessor-descriptor": {
@@ -492,7 +492,7 @@
                     "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
                     "dev": true,
                     "requires": {
-                        "kind-of": "3.2.2"
+                        "kind-of": "^3.0.2"
                     },
                     "dependencies": {
                         "kind-of": {
@@ -501,7 +501,7 @@
                             "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                             "dev": true,
                             "requires": {
-                                "is-buffer": "1.1.6"
+                                "is-buffer": "^1.1.5"
                             }
                         }
                     }
@@ -512,7 +512,7 @@
                     "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
                     "dev": true,
                     "requires": {
-                        "kind-of": "3.2.2"
+                        "kind-of": "^3.0.2"
                     },
                     "dependencies": {
                         "kind-of": {
@@ -521,7 +521,7 @@
                             "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                             "dev": true,
                             "requires": {
-                                "is-buffer": "1.1.6"
+                                "is-buffer": "^1.1.5"
                             }
                         }
                     }
@@ -532,9 +532,9 @@
                     "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
                     "dev": true,
                     "requires": {
-                        "is-accessor-descriptor": "0.1.6",
-                        "is-data-descriptor": "0.1.4",
-                        "kind-of": "5.1.0"
+                        "is-accessor-descriptor": "^0.1.6",
+                        "is-data-descriptor": "^0.1.4",
+                        "kind-of": "^5.0.0"
                     }
                 },
                 "isobject": {
@@ -558,8 +558,8 @@
             "dev": true,
             "optional": true,
             "requires": {
-                "center-align": "0.1.3",
-                "right-align": "0.1.3",
+                "center-align": "^0.1.1",
+                "right-align": "^0.1.1",
                 "wordwrap": "0.0.2"
             },
             "dependencies": {
@@ -596,9 +596,9 @@
             "integrity": "sha512-Bq6+4t+lbM8vhTs/Bef5c5AdEMtapp/iFb6+s4/Hh9MVTt8OLKH7ZOOZSCT+Ys7hsHvqv0GuMPJ1lnQJVHvxpg==",
             "dev": true,
             "requires": {
-                "inherits": "2.0.3",
-                "process-nextick-args": "2.0.0",
-                "readable-stream": "2.3.6"
+                "inherits": "^2.0.1",
+                "process-nextick-args": "^2.0.0",
+                "readable-stream": "^2.3.5"
             },
             "dependencies": {
                 "process-nextick-args": {
@@ -613,13 +613,13 @@
                     "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
                     "dev": true,
                     "requires": {
-                        "core-util-is": "1.0.2",
-                        "inherits": "2.0.3",
-                        "isarray": "1.0.0",
-                        "process-nextick-args": "2.0.0",
-                        "safe-buffer": "5.1.1",
-                        "string_decoder": "1.1.1",
-                        "util-deprecate": "1.0.2"
+                        "core-util-is": "~1.0.0",
+                        "inherits": "~2.0.3",
+                        "isarray": "~1.0.0",
+                        "process-nextick-args": "~2.0.0",
+                        "safe-buffer": "~5.1.1",
+                        "string_decoder": "~1.1.1",
+                        "util-deprecate": "~1.0.1"
                     }
                 },
                 "string_decoder": {
@@ -628,7 +628,7 @@
                     "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
                     "dev": true,
                     "requires": {
-                        "safe-buffer": "5.1.1"
+                        "safe-buffer": "~5.1.0"
                     }
                 }
             }
@@ -644,8 +644,8 @@
             "integrity": "sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA=",
             "dev": true,
             "requires": {
-                "map-visit": "1.0.0",
-                "object-visit": "1.0.1"
+                "map-visit": "^1.0.0",
+                "object-visit": "^1.0.0"
             }
         },
         "color-support": {
@@ -659,7 +659,7 @@
             "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
             "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
             "requires": {
-                "delayed-stream": "1.0.0"
+                "delayed-stream": "~1.0.0"
             }
         },
         "commander": {
@@ -686,8 +686,8 @@
             "integrity": "sha1-q6CXR9++TD5w52am5BWG4YWfxvI=",
             "dev": true,
             "requires": {
-                "ini": "1.3.5",
-                "proto-list": "1.2.4"
+                "ini": "^1.3.4",
+                "proto-list": "~1.2.1"
             }
         },
         "convert-source-map": {
@@ -732,8 +732,8 @@
                     "integrity": "sha1-bl/mfYsgXOTSL60Ft3geja3MSzA=",
                     "dev": true,
                     "requires": {
-                        "argparse": "1.0.9",
-                        "esprima": "2.7.3"
+                        "argparse": "^1.0.7",
+                        "esprima": "^2.6.0"
                     }
                 },
                 "request": {
@@ -742,26 +742,26 @@
                     "integrity": "sha1-Tf5b9r6LjNw3/Pk+BLZVd3InEN4=",
                     "dev": true,
                     "requires": {
-                        "aws-sign2": "0.6.0",
-                        "aws4": "1.6.0",
-                        "caseless": "0.11.0",
-                        "combined-stream": "1.0.5",
-                        "extend": "3.0.1",
-                        "forever-agent": "0.6.1",
-                        "form-data": "2.1.4",
-                        "har-validator": "2.0.6",
-                        "hawk": "3.1.3",
-                        "http-signature": "1.1.1",
-                        "is-typedarray": "1.0.0",
-                        "isstream": "0.1.2",
-                        "json-stringify-safe": "5.0.1",
-                        "mime-types": "2.1.17",
-                        "oauth-sign": "0.8.2",
-                        "qs": "6.3.2",
-                        "stringstream": "0.0.5",
-                        "tough-cookie": "2.3.3",
-                        "tunnel-agent": "0.4.3",
-                        "uuid": "3.1.0"
+                        "aws-sign2": "~0.6.0",
+                        "aws4": "^1.2.1",
+                        "caseless": "~0.11.0",
+                        "combined-stream": "~1.0.5",
+                        "extend": "~3.0.0",
+                        "forever-agent": "~0.6.1",
+                        "form-data": "~2.1.1",
+                        "har-validator": "~2.0.6",
+                        "hawk": "~3.1.3",
+                        "http-signature": "~1.1.0",
+                        "is-typedarray": "~1.0.0",
+                        "isstream": "~0.1.2",
+                        "json-stringify-safe": "~5.0.1",
+                        "mime-types": "~2.1.7",
+                        "oauth-sign": "~0.8.1",
+                        "qs": "~6.3.0",
+                        "stringstream": "~0.0.4",
+                        "tough-cookie": "~2.3.0",
+                        "tunnel-agent": "~0.4.1",
+                        "uuid": "^3.0.0"
                     }
                 }
             }
@@ -772,7 +772,7 @@
             "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
             "dev": true,
             "requires": {
-                "boom": "2.10.1"
+                "boom": "2.x.x"
             }
         },
         "currently-unhandled": {
@@ -781,7 +781,7 @@
             "integrity": "sha1-mI3zP+qxke95mmE2nddsF635V+o=",
             "dev": true,
             "requires": {
-                "array-find-index": "1.0.2"
+                "array-find-index": "^1.0.1"
             }
         },
         "dashdash": {
@@ -789,7 +789,7 @@
             "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
             "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
             "requires": {
-                "assert-plus": "1.0.0"
+                "assert-plus": "^1.0.0"
             },
             "dependencies": {
                 "assert-plus": {
@@ -820,7 +820,7 @@
             "integrity": "sha1-b232uF1+fEQQqTL/wmSJt46azRM=",
             "dev": true,
             "requires": {
-                "callsite": "1.0.0"
+                "callsite": "^1.0.0"
             }
         },
         "decamelize": {
@@ -841,7 +841,7 @@
             "integrity": "sha1-sJJ0O+hCfcYh6gBnzex+cN0Z83s=",
             "dev": true,
             "requires": {
-                "is-obj": "1.0.1"
+                "is-obj": "^1.0.0"
             }
         },
         "deep-is": {
@@ -862,7 +862,7 @@
             "integrity": "sha1-xlYFHpgX2f8I7YgUd/P+QBnz730=",
             "dev": true,
             "requires": {
-                "clone": "1.0.3"
+                "clone": "^1.0.2"
             }
         },
         "define-property": {
@@ -871,8 +871,8 @@
             "integrity": "sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==",
             "dev": true,
             "requires": {
-                "is-descriptor": "1.0.2",
-                "isobject": "3.0.1"
+                "is-descriptor": "^1.0.2",
+                "isobject": "^3.0.1"
             },
             "dependencies": {
                 "isobject": {
@@ -889,12 +889,12 @@
             "integrity": "sha1-U+z2mf/LyzljdpGrE7rxYIGXZuU=",
             "dev": true,
             "requires": {
-                "globby": "6.1.0",
-                "is-path-cwd": "1.0.0",
-                "is-path-in-cwd": "1.0.0",
-                "p-map": "1.2.0",
-                "pify": "3.0.0",
-                "rimraf": "2.6.2"
+                "globby": "^6.1.0",
+                "is-path-cwd": "^1.0.0",
+                "is-path-in-cwd": "^1.0.0",
+                "p-map": "^1.1.1",
+                "pify": "^3.0.0",
+                "rimraf": "^2.2.8"
             },
             "dependencies": {
                 "pify": {
@@ -946,7 +946,7 @@
             "integrity": "sha1-xhTc9n4vsUmVqRcR5aYX6KYKMds=",
             "dev": true,
             "requires": {
-                "readable-stream": "1.1.14"
+                "readable-stream": "~1.1.9"
             },
             "dependencies": {
                 "isarray": {
@@ -961,10 +961,10 @@
                     "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
                     "dev": true,
                     "requires": {
-                        "core-util-is": "1.0.2",
-                        "inherits": "2.0.3",
+                        "core-util-is": "~1.0.0",
+                        "inherits": "~2.0.1",
                         "isarray": "0.0.1",
-                        "string_decoder": "0.10.31"
+                        "string_decoder": "~0.10.x"
                     }
                 },
                 "string_decoder": {
@@ -981,10 +981,10 @@
             "integrity": "sha512-fO3Di4tBKJpYTFHAxTU00BcfWMY9w24r/x21a6rZRbsD/ToUgGxsMbiGRmB7uVAXeGKXD9MwiLZa5E97EVgIRQ==",
             "dev": true,
             "requires": {
-                "end-of-stream": "1.4.1",
-                "inherits": "2.0.3",
-                "readable-stream": "2.3.3",
-                "stream-shift": "1.0.0"
+                "end-of-stream": "^1.0.0",
+                "inherits": "^2.0.1",
+                "readable-stream": "^2.0.0",
+                "stream-shift": "^1.0.0"
             }
         },
         "ecc-jsbn": {
@@ -993,7 +993,7 @@
             "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
             "optional": true,
             "requires": {
-                "jsbn": "0.1.1"
+                "jsbn": "~0.1.0"
             }
         },
         "editorconfig": {
@@ -1002,11 +1002,11 @@
             "integrity": "sha512-WkjsUNVCu+ITKDj73QDvi0trvpdDWdkDyHybDGSXPfekLCqwmpD7CP7iPbvBgosNuLcI96XTDwNa75JyFl7tEQ==",
             "dev": true,
             "requires": {
-                "bluebird": "3.5.1",
-                "commander": "2.12.2",
-                "lru-cache": "3.2.0",
-                "semver": "5.4.1",
-                "sigmund": "1.0.1"
+                "bluebird": "^3.0.5",
+                "commander": "^2.9.0",
+                "lru-cache": "^3.2.0",
+                "semver": "^5.1.0",
+                "sigmund": "^1.0.1"
             },
             "dependencies": {
                 "lru-cache": {
@@ -1015,7 +1015,7 @@
                     "integrity": "sha1-cXibO39Tmb7IVl3aOKow0qCX7+4=",
                     "dev": true,
                     "requires": {
-                        "pseudomap": "1.0.2"
+                        "pseudomap": "^1.0.1"
                     }
                 }
             }
@@ -1026,7 +1026,7 @@
             "integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
             "dev": true,
             "requires": {
-                "once": "1.4.0"
+                "once": "^1.4.0"
             }
         },
         "error-ex": {
@@ -1035,7 +1035,7 @@
             "integrity": "sha1-+FWobOYa3E6GIcPNoh56dhLDqNw=",
             "dev": true,
             "requires": {
-                "is-arrayish": "0.2.1"
+                "is-arrayish": "^0.2.1"
             }
         },
         "escape-string-regexp": {
@@ -1050,11 +1050,11 @@
             "integrity": "sha1-WltTr0aTEQvrsIZ6o0MN07cKEBg=",
             "dev": true,
             "requires": {
-                "esprima": "2.7.3",
-                "estraverse": "1.9.3",
-                "esutils": "2.0.2",
-                "optionator": "0.8.2",
-                "source-map": "0.2.0"
+                "esprima": "^2.7.1",
+                "estraverse": "^1.9.1",
+                "esutils": "^2.0.2",
+                "optionator": "^0.8.1",
+                "source-map": "~0.2.0"
             },
             "dependencies": {
                 "esprima": {
@@ -1070,7 +1070,7 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "amdefine": "1.0.1"
+                        "amdefine": ">=0.0.4"
                     }
                 }
             }
@@ -1098,13 +1098,13 @@
             "integrity": "sha1-SrTJoPWlTbkzi0w02Gv86PSzVXE=",
             "dev": true,
             "requires": {
-                "duplexer": "0.1.1",
-                "from": "0.1.7",
-                "map-stream": "0.1.0",
+                "duplexer": "~0.1.1",
+                "from": "~0",
+                "map-stream": "~0.1.0",
                 "pause-stream": "0.0.11",
-                "split": "0.3.3",
-                "stream-combiner": "0.0.4",
-                "through": "2.3.8"
+                "split": "0.3",
+                "stream-combiner": "~0.0.4",
+                "through": "~2.3.1"
             }
         },
         "expand-brackets": {
@@ -1113,7 +1113,7 @@
             "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
             "dev": true,
             "requires": {
-                "is-posix-bracket": "0.1.1"
+                "is-posix-bracket": "^0.1.0"
             }
         },
         "expand-range": {
@@ -1122,7 +1122,7 @@
             "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
             "dev": true,
             "requires": {
-                "fill-range": "2.2.4"
+                "fill-range": "^2.1.0"
             }
         },
         "expand-tilde": {
@@ -1131,7 +1131,7 @@
             "integrity": "sha1-l+gBqgUt8CRU3kawK/YhZCzchQI=",
             "dev": true,
             "requires": {
-                "homedir-polyfill": "1.0.1"
+                "homedir-polyfill": "^1.0.1"
             }
         },
         "extend": {
@@ -1145,7 +1145,7 @@
             "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
             "dev": true,
             "requires": {
-                "is-extendable": "0.1.1"
+                "is-extendable": "^0.1.0"
             }
         },
         "extglob": {
@@ -1154,7 +1154,7 @@
             "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
             "dev": true,
             "requires": {
-                "is-extglob": "1.0.0"
+                "is-extglob": "^1.0.0"
             },
             "dependencies": {
                 "is-extglob": {
@@ -1176,8 +1176,8 @@
             "integrity": "sha1-Rb4X0Cu5kX1gzP/UmVyZnmyMmUg=",
             "dev": true,
             "requires": {
-                "chalk": "1.1.3",
-                "time-stamp": "1.1.0"
+                "chalk": "^1.1.1",
+                "time-stamp": "^1.0.0"
             }
         },
         "fast-deep-equal": {
@@ -1202,7 +1202,7 @@
             "integrity": "sha1-JcfInLH5B3+IkbvmHY85Dq4lbx4=",
             "dev": true,
             "requires": {
-                "pend": "1.2.0"
+                "pend": "~1.2.0"
             }
         },
         "filename-regex": {
@@ -1217,8 +1217,8 @@
             "integrity": "sha1-WI74lzxmI7KnbfRlEFaWuWqsgGc=",
             "dev": true,
             "requires": {
-                "glob": "5.0.15",
-                "minimatch": "2.0.10"
+                "glob": "5.x",
+                "minimatch": "2.x"
             },
             "dependencies": {
                 "glob": {
@@ -1227,11 +1227,11 @@
                     "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
                     "dev": true,
                     "requires": {
-                        "inflight": "1.0.6",
-                        "inherits": "2.0.3",
-                        "minimatch": "2.0.10",
-                        "once": "1.4.0",
-                        "path-is-absolute": "1.0.1"
+                        "inflight": "^1.0.4",
+                        "inherits": "2",
+                        "minimatch": "2 || 3",
+                        "once": "^1.3.0",
+                        "path-is-absolute": "^1.0.0"
                     }
                 },
                 "minimatch": {
@@ -1240,7 +1240,7 @@
                     "integrity": "sha1-jQh8OcazjAAbl/ynzm0OHoCvusc=",
                     "dev": true,
                     "requires": {
-                        "brace-expansion": "1.1.8"
+                        "brace-expansion": "^1.0.0"
                     }
                 }
             }
@@ -1251,11 +1251,11 @@
             "integrity": "sha512-cnrcCbj01+j2gTG921VZPnHbjmdAf8oQV/iGeV2kZxGSyfYjjTyY79ErsK1WJWMpw6DaApEX72binqJE+/d+5Q==",
             "dev": true,
             "requires": {
-                "is-number": "2.1.0",
-                "isobject": "2.1.0",
-                "randomatic": "3.0.0",
-                "repeat-element": "1.1.2",
-                "repeat-string": "1.6.1"
+                "is-number": "^2.1.0",
+                "isobject": "^2.0.0",
+                "randomatic": "^3.0.0",
+                "repeat-element": "^1.1.2",
+                "repeat-string": "^1.5.2"
             }
         },
         "find-index": {
@@ -1270,8 +1270,8 @@
             "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
             "dev": true,
             "requires": {
-                "path-exists": "2.1.0",
-                "pinkie-promise": "2.0.1"
+                "path-exists": "^2.0.0",
+                "pinkie-promise": "^2.0.0"
             }
         },
         "findup-sync": {
@@ -1280,10 +1280,10 @@
             "integrity": "sha1-kyaxSIwi0aYIhlCoaQGy2akKLLw=",
             "dev": true,
             "requires": {
-                "detect-file": "1.0.0",
-                "is-glob": "3.1.0",
-                "micromatch": "3.1.9",
-                "resolve-dir": "1.0.1"
+                "detect-file": "^1.0.0",
+                "is-glob": "^3.1.0",
+                "micromatch": "^3.0.4",
+                "resolve-dir": "^1.0.1"
             },
             "dependencies": {
                 "arr-diff": {
@@ -1304,18 +1304,18 @@
                     "integrity": "sha512-SO5lYHA3vO6gz66erVvedSCkp7AKWdv6VcQ2N4ysXfPxdAlxAMMAdwegGGcv1Bqwm7naF1hNdk5d6AAIEHV2nQ==",
                     "dev": true,
                     "requires": {
-                        "arr-flatten": "1.1.0",
-                        "array-unique": "0.3.2",
-                        "define-property": "1.0.0",
-                        "extend-shallow": "2.0.1",
-                        "fill-range": "4.0.0",
-                        "isobject": "3.0.1",
-                        "kind-of": "6.0.2",
-                        "repeat-element": "1.1.2",
-                        "snapdragon": "0.8.1",
-                        "snapdragon-node": "2.1.1",
-                        "split-string": "3.1.0",
-                        "to-regex": "3.0.2"
+                        "arr-flatten": "^1.1.0",
+                        "array-unique": "^0.3.2",
+                        "define-property": "^1.0.0",
+                        "extend-shallow": "^2.0.1",
+                        "fill-range": "^4.0.0",
+                        "isobject": "^3.0.1",
+                        "kind-of": "^6.0.2",
+                        "repeat-element": "^1.1.2",
+                        "snapdragon": "^0.8.1",
+                        "snapdragon-node": "^2.0.1",
+                        "split-string": "^3.0.2",
+                        "to-regex": "^3.0.1"
                     },
                     "dependencies": {
                         "define-property": {
@@ -1324,7 +1324,7 @@
                             "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
                             "dev": true,
                             "requires": {
-                                "is-descriptor": "1.0.2"
+                                "is-descriptor": "^1.0.0"
                             }
                         },
                         "extend-shallow": {
@@ -1333,7 +1333,7 @@
                             "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                             "dev": true,
                             "requires": {
-                                "is-extendable": "0.1.1"
+                                "is-extendable": "^0.1.0"
                             }
                         }
                     }
@@ -1353,13 +1353,13 @@
                     "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
                     "dev": true,
                     "requires": {
-                        "debug": "2.6.9",
-                        "define-property": "0.2.5",
-                        "extend-shallow": "2.0.1",
-                        "posix-character-classes": "0.1.1",
-                        "regex-not": "1.0.2",
-                        "snapdragon": "0.8.1",
-                        "to-regex": "3.0.2"
+                        "debug": "^2.3.3",
+                        "define-property": "^0.2.5",
+                        "extend-shallow": "^2.0.1",
+                        "posix-character-classes": "^0.1.0",
+                        "regex-not": "^1.0.0",
+                        "snapdragon": "^0.8.1",
+                        "to-regex": "^3.0.1"
                     },
                     "dependencies": {
                         "define-property": {
@@ -1368,7 +1368,7 @@
                             "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
                             "dev": true,
                             "requires": {
-                                "is-descriptor": "0.1.6"
+                                "is-descriptor": "^0.1.0"
                             }
                         },
                         "extend-shallow": {
@@ -1377,7 +1377,7 @@
                             "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                             "dev": true,
                             "requires": {
-                                "is-extendable": "0.1.1"
+                                "is-extendable": "^0.1.0"
                             }
                         },
                         "is-descriptor": {
@@ -1386,9 +1386,9 @@
                             "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
                             "dev": true,
                             "requires": {
-                                "is-accessor-descriptor": "0.1.6",
-                                "is-data-descriptor": "0.1.4",
-                                "kind-of": "5.1.0"
+                                "is-accessor-descriptor": "^0.1.6",
+                                "is-data-descriptor": "^0.1.4",
+                                "kind-of": "^5.0.0"
                             }
                         },
                         "kind-of": {
@@ -1405,8 +1405,8 @@
                     "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
                     "dev": true,
                     "requires": {
-                        "assign-symbols": "1.0.0",
-                        "is-extendable": "1.0.1"
+                        "assign-symbols": "^1.0.0",
+                        "is-extendable": "^1.0.1"
                     },
                     "dependencies": {
                         "is-extendable": {
@@ -1415,7 +1415,7 @@
                             "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
                             "dev": true,
                             "requires": {
-                                "is-plain-object": "2.0.4"
+                                "is-plain-object": "^2.0.4"
                             }
                         }
                     }
@@ -1426,14 +1426,14 @@
                     "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
                     "dev": true,
                     "requires": {
-                        "array-unique": "0.3.2",
-                        "define-property": "1.0.0",
-                        "expand-brackets": "2.1.4",
-                        "extend-shallow": "2.0.1",
-                        "fragment-cache": "0.2.1",
-                        "regex-not": "1.0.2",
-                        "snapdragon": "0.8.1",
-                        "to-regex": "3.0.2"
+                        "array-unique": "^0.3.2",
+                        "define-property": "^1.0.0",
+                        "expand-brackets": "^2.1.4",
+                        "extend-shallow": "^2.0.1",
+                        "fragment-cache": "^0.2.1",
+                        "regex-not": "^1.0.0",
+                        "snapdragon": "^0.8.1",
+                        "to-regex": "^3.0.1"
                     },
                     "dependencies": {
                         "define-property": {
@@ -1442,7 +1442,7 @@
                             "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
                             "dev": true,
                             "requires": {
-                                "is-descriptor": "1.0.2"
+                                "is-descriptor": "^1.0.0"
                             }
                         },
                         "extend-shallow": {
@@ -1451,7 +1451,7 @@
                             "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                             "dev": true,
                             "requires": {
-                                "is-extendable": "0.1.1"
+                                "is-extendable": "^0.1.0"
                             }
                         }
                     }
@@ -1462,10 +1462,10 @@
                     "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
                     "dev": true,
                     "requires": {
-                        "extend-shallow": "2.0.1",
-                        "is-number": "3.0.0",
-                        "repeat-string": "1.6.1",
-                        "to-regex-range": "2.1.1"
+                        "extend-shallow": "^2.0.1",
+                        "is-number": "^3.0.0",
+                        "repeat-string": "^1.6.1",
+                        "to-regex-range": "^2.1.0"
                     },
                     "dependencies": {
                         "extend-shallow": {
@@ -1474,7 +1474,7 @@
                             "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                             "dev": true,
                             "requires": {
-                                "is-extendable": "0.1.1"
+                                "is-extendable": "^0.1.0"
                             }
                         }
                     }
@@ -1485,7 +1485,7 @@
                     "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
                     "dev": true,
                     "requires": {
-                        "kind-of": "3.2.2"
+                        "kind-of": "^3.0.2"
                     },
                     "dependencies": {
                         "kind-of": {
@@ -1494,7 +1494,7 @@
                             "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                             "dev": true,
                             "requires": {
-                                "is-buffer": "1.1.6"
+                                "is-buffer": "^1.1.5"
                             }
                         }
                     }
@@ -1505,7 +1505,7 @@
                     "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
                     "dev": true,
                     "requires": {
-                        "kind-of": "3.2.2"
+                        "kind-of": "^3.0.2"
                     },
                     "dependencies": {
                         "kind-of": {
@@ -1514,7 +1514,7 @@
                             "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                             "dev": true,
                             "requires": {
-                                "is-buffer": "1.1.6"
+                                "is-buffer": "^1.1.5"
                             }
                         }
                     }
@@ -1525,7 +1525,7 @@
                     "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
                     "dev": true,
                     "requires": {
-                        "kind-of": "3.2.2"
+                        "kind-of": "^3.0.2"
                     },
                     "dependencies": {
                         "kind-of": {
@@ -1534,7 +1534,7 @@
                             "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                             "dev": true,
                             "requires": {
-                                "is-buffer": "1.1.6"
+                                "is-buffer": "^1.1.5"
                             }
                         }
                     }
@@ -1557,19 +1557,19 @@
                     "integrity": "sha512-SlIz6sv5UPaAVVFRKodKjCg48EbNoIhgetzfK/Cy0v5U52Z6zB136M8tp0UC9jM53LYbmIRihJszvvqpKkfm9g==",
                     "dev": true,
                     "requires": {
-                        "arr-diff": "4.0.0",
-                        "array-unique": "0.3.2",
-                        "braces": "2.3.1",
-                        "define-property": "2.0.2",
-                        "extend-shallow": "3.0.2",
-                        "extglob": "2.0.4",
-                        "fragment-cache": "0.2.1",
-                        "kind-of": "6.0.2",
-                        "nanomatch": "1.2.9",
-                        "object.pick": "1.3.0",
-                        "regex-not": "1.0.2",
-                        "snapdragon": "0.8.1",
-                        "to-regex": "3.0.2"
+                        "arr-diff": "^4.0.0",
+                        "array-unique": "^0.3.2",
+                        "braces": "^2.3.1",
+                        "define-property": "^2.0.2",
+                        "extend-shallow": "^3.0.2",
+                        "extglob": "^2.0.4",
+                        "fragment-cache": "^0.2.1",
+                        "kind-of": "^6.0.2",
+                        "nanomatch": "^1.2.9",
+                        "object.pick": "^1.3.0",
+                        "regex-not": "^1.0.0",
+                        "snapdragon": "^0.8.1",
+                        "to-regex": "^3.0.1"
                     }
                 }
             }
@@ -1580,11 +1580,11 @@
             "integrity": "sha1-s33IRLdqL15wgeiE98CuNE8VNHY=",
             "dev": true,
             "requires": {
-                "expand-tilde": "2.0.2",
-                "is-plain-object": "2.0.4",
-                "object.defaults": "1.1.0",
-                "object.pick": "1.3.0",
-                "parse-filepath": "1.0.2"
+                "expand-tilde": "^2.0.2",
+                "is-plain-object": "^2.0.3",
+                "object.defaults": "^1.1.0",
+                "object.pick": "^1.2.0",
+                "parse-filepath": "^1.0.1"
             }
         },
         "first-chunk-stream": {
@@ -1604,7 +1604,7 @@
             "resolved": "https://registry.npmjs.org/fmix/-/fmix-0.1.0.tgz",
             "integrity": "sha1-x7vxJN7ELJ0ZHPuUfQqXeN2YbAw=",
             "requires": {
-                "imul": "1.0.1"
+                "imul": "^1.0.0"
             }
         },
         "for-in": {
@@ -1619,7 +1619,7 @@
             "integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
             "dev": true,
             "requires": {
-                "for-in": "1.0.2"
+                "for-in": "^1.0.1"
             }
         },
         "forever-agent": {
@@ -1633,9 +1633,9 @@
             "integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE=",
             "dev": true,
             "requires": {
-                "asynckit": "0.4.0",
-                "combined-stream": "1.0.5",
-                "mime-types": "2.1.17"
+                "asynckit": "^0.4.0",
+                "combined-stream": "^1.0.5",
+                "mime-types": "^2.1.12"
             }
         },
         "fragment-cache": {
@@ -1644,7 +1644,7 @@
             "integrity": "sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=",
             "dev": true,
             "requires": {
-                "map-cache": "0.2.2"
+                "map-cache": "^0.2.2"
             }
         },
         "from": {
@@ -1658,7 +1658,7 @@
             "resolved": "https://registry.npmjs.org/fs-temp/-/fs-temp-1.1.2.tgz",
             "integrity": "sha1-zFLwOLvv5RD2vNCexZK3nQ9pJT8=",
             "requires": {
-                "random-path": "0.1.1"
+                "random-path": "^0.1.0"
             }
         },
         "fs.realpath": {
@@ -1673,10 +1673,10 @@
             "integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=",
             "dev": true,
             "requires": {
-                "graceful-fs": "4.1.11",
-                "inherits": "2.0.3",
-                "mkdirp": "0.5.1",
-                "rimraf": "2.6.2"
+                "graceful-fs": "^4.1.2",
+                "inherits": "~2.0.0",
+                "mkdirp": ">=0.5 0",
+                "rimraf": "2"
             }
         },
         "gaze": {
@@ -1685,7 +1685,7 @@
             "integrity": "sha1-QLcJU30k0dRXZ9takIaJ3+aaxE8=",
             "dev": true,
             "requires": {
-                "globule": "0.1.0"
+                "globule": "~0.1.0"
             }
         },
         "generate-function": {
@@ -1700,7 +1700,7 @@
             "integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=",
             "dev": true,
             "requires": {
-                "is-property": "1.0.2"
+                "is-property": "^1.0.0"
             }
         },
         "get-stdin": {
@@ -1720,7 +1720,7 @@
             "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
             "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
             "requires": {
-                "assert-plus": "1.0.0"
+                "assert-plus": "^1.0.0"
             },
             "dependencies": {
                 "assert-plus": {
@@ -1736,12 +1736,12 @@
             "integrity": "sha1-wZyd+aAocC1nhhI4SmVSQExjbRU=",
             "dev": true,
             "requires": {
-                "fs.realpath": "1.0.0",
-                "inflight": "1.0.6",
-                "inherits": "2.0.3",
-                "minimatch": "3.0.4",
-                "once": "1.4.0",
-                "path-is-absolute": "1.0.1"
+                "fs.realpath": "^1.0.0",
+                "inflight": "^1.0.4",
+                "inherits": "2",
+                "minimatch": "^3.0.4",
+                "once": "^1.3.0",
+                "path-is-absolute": "^1.0.0"
             }
         },
         "glob-base": {
@@ -1750,8 +1750,8 @@
             "integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
             "dev": true,
             "requires": {
-                "glob-parent": "2.0.0",
-                "is-glob": "2.0.1"
+                "glob-parent": "^2.0.0",
+                "is-glob": "^2.0.0"
             },
             "dependencies": {
                 "glob-parent": {
@@ -1760,7 +1760,7 @@
                     "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
                     "dev": true,
                     "requires": {
-                        "is-glob": "2.0.1"
+                        "is-glob": "^2.0.0"
                     }
                 },
                 "is-extglob": {
@@ -1775,7 +1775,7 @@
                     "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
                     "dev": true,
                     "requires": {
-                        "is-extglob": "1.0.0"
+                        "is-extglob": "^1.0.0"
                     }
                 }
             }
@@ -1786,8 +1786,8 @@
             "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
             "dev": true,
             "requires": {
-                "is-glob": "3.1.0",
-                "path-dirname": "1.0.2"
+                "is-glob": "^3.1.0",
+                "path-dirname": "^1.0.0"
             }
         },
         "glob-stream": {
@@ -1796,14 +1796,14 @@
             "integrity": "sha1-pVZlqajM3EGRWofHAeMtTgFvrSI=",
             "dev": true,
             "requires": {
-                "extend": "3.0.1",
-                "glob": "5.0.15",
-                "glob-parent": "3.1.0",
-                "micromatch": "2.3.11",
-                "ordered-read-streams": "0.3.0",
-                "through2": "0.6.5",
-                "to-absolute-glob": "0.1.1",
-                "unique-stream": "2.2.1"
+                "extend": "^3.0.0",
+                "glob": "^5.0.3",
+                "glob-parent": "^3.0.0",
+                "micromatch": "^2.3.7",
+                "ordered-read-streams": "^0.3.0",
+                "through2": "^0.6.0",
+                "to-absolute-glob": "^0.1.1",
+                "unique-stream": "^2.0.2"
             },
             "dependencies": {
                 "glob": {
@@ -1812,11 +1812,11 @@
                     "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
                     "dev": true,
                     "requires": {
-                        "inflight": "1.0.6",
-                        "inherits": "2.0.3",
-                        "minimatch": "3.0.4",
-                        "once": "1.4.0",
-                        "path-is-absolute": "1.0.1"
+                        "inflight": "^1.0.4",
+                        "inherits": "2",
+                        "minimatch": "2 || 3",
+                        "once": "^1.3.0",
+                        "path-is-absolute": "^1.0.0"
                     }
                 },
                 "isarray": {
@@ -1831,10 +1831,10 @@
                     "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
                     "dev": true,
                     "requires": {
-                        "core-util-is": "1.0.2",
-                        "inherits": "2.0.3",
+                        "core-util-is": "~1.0.0",
+                        "inherits": "~2.0.1",
                         "isarray": "0.0.1",
-                        "string_decoder": "0.10.31"
+                        "string_decoder": "~0.10.x"
                     }
                 },
                 "string_decoder": {
@@ -1849,8 +1849,8 @@
                     "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
                     "dev": true,
                     "requires": {
-                        "readable-stream": "1.0.34",
-                        "xtend": "4.0.1"
+                        "readable-stream": ">=1.0.33-1 <1.1.0-0",
+                        "xtend": ">=4.0.0 <4.1.0-0"
                     }
                 }
             }
@@ -1861,7 +1861,7 @@
             "integrity": "sha1-uVtKjfdLOcgymLDAXJeLTZo7cQs=",
             "dev": true,
             "requires": {
-                "gaze": "0.5.2"
+                "gaze": "^0.5.1"
             }
         },
         "glob2base": {
@@ -1870,7 +1870,7 @@
             "integrity": "sha1-nUGbPijxLoOjYhZKJ3BVkiycDVY=",
             "dev": true,
             "requires": {
-                "find-index": "0.1.1"
+                "find-index": "^0.1.1"
             }
         },
         "global-modules": {
@@ -1879,9 +1879,9 @@
             "integrity": "sha512-sKzpEkf11GpOFuw0Zzjzmt4B4UZwjOcG757PPvrfhxcLFbq0wpsgpOqxpxtxFiCG4DtG93M6XRVbF2oGdev7bg==",
             "dev": true,
             "requires": {
-                "global-prefix": "1.0.2",
-                "is-windows": "1.0.2",
-                "resolve-dir": "1.0.1"
+                "global-prefix": "^1.0.1",
+                "is-windows": "^1.0.1",
+                "resolve-dir": "^1.0.0"
             }
         },
         "global-prefix": {
@@ -1890,11 +1890,11 @@
             "integrity": "sha1-2/dDxsFJklk8ZVVoy2btMsASLr4=",
             "dev": true,
             "requires": {
-                "expand-tilde": "2.0.2",
-                "homedir-polyfill": "1.0.1",
-                "ini": "1.3.5",
-                "is-windows": "1.0.2",
-                "which": "1.3.0"
+                "expand-tilde": "^2.0.2",
+                "homedir-polyfill": "^1.0.1",
+                "ini": "^1.3.4",
+                "is-windows": "^1.0.1",
+                "which": "^1.2.14"
             }
         },
         "globby": {
@@ -1903,11 +1903,11 @@
             "integrity": "sha1-9abXDoOV4hyFj7BInWTfAkJNUGw=",
             "dev": true,
             "requires": {
-                "array-union": "1.0.2",
-                "glob": "7.1.2",
-                "object-assign": "4.1.1",
-                "pify": "2.3.0",
-                "pinkie-promise": "2.0.1"
+                "array-union": "^1.0.1",
+                "glob": "^7.0.3",
+                "object-assign": "^4.0.1",
+                "pify": "^2.0.0",
+                "pinkie-promise": "^2.0.0"
             },
             "dependencies": {
                 "object-assign": {
@@ -1924,9 +1924,9 @@
             "integrity": "sha1-2cjt3h2nnRJaFRt5UzuXhnY0auU=",
             "dev": true,
             "requires": {
-                "glob": "3.1.21",
-                "lodash": "1.0.2",
-                "minimatch": "0.2.14"
+                "glob": "~3.1.21",
+                "lodash": "~1.0.1",
+                "minimatch": "~0.2.11"
             },
             "dependencies": {
                 "glob": {
@@ -1935,9 +1935,9 @@
                     "integrity": "sha1-0p4KBV3qUTj00H7UDomC6DwgZs0=",
                     "dev": true,
                     "requires": {
-                        "graceful-fs": "1.2.3",
-                        "inherits": "1.0.2",
-                        "minimatch": "0.2.14"
+                        "graceful-fs": "~1.2.0",
+                        "inherits": "1",
+                        "minimatch": "~0.2.11"
                     }
                 },
                 "graceful-fs": {
@@ -1964,8 +1964,8 @@
                     "integrity": "sha1-x054BXT2PG+aCQ6Q775u9TpqdWo=",
                     "dev": true,
                     "requires": {
-                        "lru-cache": "2.7.3",
-                        "sigmund": "1.0.1"
+                        "lru-cache": "2",
+                        "sigmund": "~1.0.0"
                     }
                 }
             }
@@ -1976,7 +1976,7 @@
             "integrity": "sha1-f+DxmfV6yQbPUS/urY+Q7kooT8U=",
             "dev": true,
             "requires": {
-                "sparkles": "1.0.0"
+                "sparkles": "^1.0.0"
             }
         },
         "graceful-fs": {
@@ -1997,19 +1997,19 @@
             "integrity": "sha1-VxzkWSjdQK9lFPxAEYZgFsE4RbQ=",
             "dev": true,
             "requires": {
-                "archy": "1.0.0",
-                "chalk": "1.1.3",
-                "deprecated": "0.0.1",
-                "gulp-util": "3.0.8",
-                "interpret": "1.1.0",
-                "liftoff": "2.5.0",
-                "minimist": "1.2.0",
-                "orchestrator": "0.3.8",
-                "pretty-hrtime": "1.0.3",
-                "semver": "4.3.6",
-                "tildify": "1.2.0",
-                "v8flags": "2.1.1",
-                "vinyl-fs": "0.3.14"
+                "archy": "^1.0.0",
+                "chalk": "^1.0.0",
+                "deprecated": "^0.0.1",
+                "gulp-util": "^3.0.0",
+                "interpret": "^1.0.0",
+                "liftoff": "^2.1.0",
+                "minimist": "^1.1.0",
+                "orchestrator": "^0.3.0",
+                "pretty-hrtime": "^1.0.0",
+                "semver": "^4.1.0",
+                "tildify": "^1.0.0",
+                "v8flags": "^2.0.2",
+                "vinyl-fs": "^0.3.0"
             },
             "dependencies": {
                 "clone": {
@@ -2024,10 +2024,10 @@
                     "integrity": "sha1-xstz0yJsHv7wTePFbQEvAzd+4V8=",
                     "dev": true,
                     "requires": {
-                        "inflight": "1.0.6",
-                        "inherits": "2.0.3",
-                        "minimatch": "2.0.10",
-                        "once": "1.4.0"
+                        "inflight": "^1.0.4",
+                        "inherits": "2",
+                        "minimatch": "^2.0.1",
+                        "once": "^1.3.0"
                     }
                 },
                 "glob-stream": {
@@ -2036,12 +2036,12 @@
                     "integrity": "sha1-kXCl8St5Awb9/lmPMT+PeVT9FDs=",
                     "dev": true,
                     "requires": {
-                        "glob": "4.5.3",
-                        "glob2base": "0.0.12",
-                        "minimatch": "2.0.10",
-                        "ordered-read-streams": "0.1.0",
-                        "through2": "0.6.5",
-                        "unique-stream": "1.0.0"
+                        "glob": "^4.3.1",
+                        "glob2base": "^0.0.12",
+                        "minimatch": "^2.0.1",
+                        "ordered-read-streams": "^0.1.0",
+                        "through2": "^0.6.1",
+                        "unique-stream": "^1.0.0"
                     }
                 },
                 "graceful-fs": {
@@ -2050,7 +2050,7 @@
                     "integrity": "sha1-dhPHeKGv6mLyXGMKCG1/Osu92Bg=",
                     "dev": true,
                     "requires": {
-                        "natives": "1.1.1"
+                        "natives": "^1.1.0"
                     }
                 },
                 "isarray": {
@@ -2065,7 +2065,7 @@
                     "integrity": "sha1-jQh8OcazjAAbl/ynzm0OHoCvusc=",
                     "dev": true,
                     "requires": {
-                        "brace-expansion": "1.1.8"
+                        "brace-expansion": "^1.0.0"
                     }
                 },
                 "ordered-read-streams": {
@@ -2080,10 +2080,10 @@
                     "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
                     "dev": true,
                     "requires": {
-                        "core-util-is": "1.0.2",
-                        "inherits": "2.0.3",
+                        "core-util-is": "~1.0.0",
+                        "inherits": "~2.0.1",
                         "isarray": "0.0.1",
-                        "string_decoder": "0.10.31"
+                        "string_decoder": "~0.10.x"
                     }
                 },
                 "semver": {
@@ -2104,8 +2104,8 @@
                     "integrity": "sha1-hbiGLzhEtabV7IRnqTWYFzo295Q=",
                     "dev": true,
                     "requires": {
-                        "first-chunk-stream": "1.0.0",
-                        "is-utf8": "0.2.1"
+                        "first-chunk-stream": "^1.0.0",
+                        "is-utf8": "^0.2.0"
                     }
                 },
                 "through2": {
@@ -2114,8 +2114,8 @@
                     "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
                     "dev": true,
                     "requires": {
-                        "readable-stream": "1.0.34",
-                        "xtend": "4.0.1"
+                        "readable-stream": ">=1.0.33-1 <1.1.0-0",
+                        "xtend": ">=4.0.0 <4.1.0-0"
                     }
                 },
                 "unique-stream": {
@@ -2130,8 +2130,8 @@
                     "integrity": "sha1-LzVsh6VQolVGHza76ypbqL94SEc=",
                     "dev": true,
                     "requires": {
-                        "clone": "0.2.0",
-                        "clone-stats": "0.0.1"
+                        "clone": "^0.2.0",
+                        "clone-stats": "^0.0.1"
                     }
                 },
                 "vinyl-fs": {
@@ -2140,14 +2140,14 @@
                     "integrity": "sha1-mmhRzhysHBzqX+hsCTHWIMLPqeY=",
                     "dev": true,
                     "requires": {
-                        "defaults": "1.0.3",
-                        "glob-stream": "3.1.18",
-                        "glob-watcher": "0.0.6",
-                        "graceful-fs": "3.0.11",
-                        "mkdirp": "0.5.1",
-                        "strip-bom": "1.0.0",
-                        "through2": "0.6.5",
-                        "vinyl": "0.4.6"
+                        "defaults": "^1.0.0",
+                        "glob-stream": "^3.1.5",
+                        "glob-watcher": "^0.0.6",
+                        "graceful-fs": "^3.0.0",
+                        "mkdirp": "^0.5.0",
+                        "strip-bom": "^1.0.0",
+                        "through2": "^0.6.1",
+                        "vinyl": "^0.4.0"
                     }
                 }
             }
@@ -2158,9 +2158,9 @@
             "integrity": "sha1-AMOQuSigeZslGsz2MaoJ4BzGKZw=",
             "dev": true,
             "requires": {
-                "deep-assign": "1.0.0",
-                "stat-mode": "0.2.2",
-                "through2": "2.0.3"
+                "deep-assign": "^1.0.0",
+                "stat-mode": "^0.2.0",
+                "through2": "^2.0.0"
             }
         },
         "gulp-coveralls": {
@@ -2169,9 +2169,9 @@
             "integrity": "sha1-L2IKyN9i0LhrS73mTaNnzEGhkMk=",
             "dev": true,
             "requires": {
-                "coveralls": "2.13.3",
-                "gulp-util": "3.0.8",
-                "through2": "1.1.1"
+                "coveralls": "^2.11.2",
+                "gulp-util": "^3.0.4",
+                "through2": "^1.1.1"
             },
             "dependencies": {
                 "isarray": {
@@ -2186,10 +2186,10 @@
                     "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
                     "dev": true,
                     "requires": {
-                        "core-util-is": "1.0.2",
-                        "inherits": "2.0.3",
+                        "core-util-is": "~1.0.0",
+                        "inherits": "~2.0.1",
                         "isarray": "0.0.1",
-                        "string_decoder": "0.10.31"
+                        "string_decoder": "~0.10.x"
                     }
                 },
                 "string_decoder": {
@@ -2204,8 +2204,8 @@
                     "integrity": "sha1-CEfLxESfNAVXTb3M2buEG4OsNUU=",
                     "dev": true,
                     "requires": {
-                        "readable-stream": "1.1.14",
-                        "xtend": "4.0.1"
+                        "readable-stream": ">=1.1.13-1 <1.2.0-0",
+                        "xtend": ">=4.0.0 <4.1.0-0"
                     }
                 }
             }
@@ -2216,9 +2216,9 @@
             "integrity": "sha1-oF4Rr/sHz33PQafeHLe2OsN4PnM=",
             "dev": true,
             "requires": {
-                "multimatch": "2.1.0",
-                "plugin-error": "0.1.2",
-                "streamfilter": "1.0.7"
+                "multimatch": "^2.0.0",
+                "plugin-error": "^0.1.2",
+                "streamfilter": "^1.0.5"
             },
             "dependencies": {
                 "arr-diff": {
@@ -2227,8 +2227,8 @@
                     "integrity": "sha1-aHwydYFjWI/vfeezb6vklesaOZo=",
                     "dev": true,
                     "requires": {
-                        "arr-flatten": "1.1.0",
-                        "array-slice": "0.2.3"
+                        "arr-flatten": "^1.0.1",
+                        "array-slice": "^0.2.3"
                     }
                 },
                 "arr-union": {
@@ -2249,7 +2249,7 @@
                     "integrity": "sha1-Gda/lN/AnXa6cR85uHLSH/TdkHE=",
                     "dev": true,
                     "requires": {
-                        "kind-of": "1.1.0"
+                        "kind-of": "^1.1.0"
                     }
                 },
                 "kind-of": {
@@ -2264,11 +2264,11 @@
                     "integrity": "sha1-O5uzM1zPAPQl4HQ34ZJ2ln2kes4=",
                     "dev": true,
                     "requires": {
-                        "ansi-cyan": "0.1.1",
-                        "ansi-red": "0.1.1",
-                        "arr-diff": "1.1.0",
-                        "arr-union": "2.1.0",
-                        "extend-shallow": "1.1.4"
+                        "ansi-cyan": "^0.1.1",
+                        "ansi-red": "^0.1.1",
+                        "arr-diff": "^1.0.1",
+                        "arr-union": "^2.0.1",
+                        "extend-shallow": "^1.1.2"
                     }
                 }
             }
@@ -2279,8 +2279,8 @@
             "integrity": "sha1-FbdBFF6Dqcb1CIYkG1fMWHHxUak=",
             "dev": true,
             "requires": {
-                "through2": "0.6.5",
-                "vinyl": "0.4.6"
+                "through2": "~0.6.5",
+                "vinyl": "~0.4.6"
             },
             "dependencies": {
                 "clone": {
@@ -2301,10 +2301,10 @@
                     "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
                     "dev": true,
                     "requires": {
-                        "core-util-is": "1.0.2",
-                        "inherits": "2.0.3",
+                        "core-util-is": "~1.0.0",
+                        "inherits": "~2.0.1",
                         "isarray": "0.0.1",
-                        "string_decoder": "0.10.31"
+                        "string_decoder": "~0.10.x"
                     }
                 },
                 "string_decoder": {
@@ -2319,8 +2319,8 @@
                     "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
                     "dev": true,
                     "requires": {
-                        "readable-stream": "1.0.34",
-                        "xtend": "4.0.1"
+                        "readable-stream": ">=1.0.33-1 <1.1.0-0",
+                        "xtend": ">=4.0.0 <4.1.0-0"
                     }
                 },
                 "vinyl": {
@@ -2329,8 +2329,8 @@
                     "integrity": "sha1-LzVsh6VQolVGHza76ypbqL94SEc=",
                     "dev": true,
                     "requires": {
-                        "clone": "0.2.0",
-                        "clone-stats": "0.0.1"
+                        "clone": "^0.2.0",
+                        "clone-stats": "^0.0.1"
                     }
                 }
             }
@@ -2341,11 +2341,11 @@
             "integrity": "sha512-mUPSsibfnRT04Iy9AfrvC8kfcJZJFYt5qfr6TTQHHBZ1qviz2qqfAf7DLS2Frp33ycyZJvm6n9cwNgV00A95TA==",
             "dev": true,
             "requires": {
-                "deepmerge": "2.1.1",
-                "detect-indent": "5.0.0",
-                "js-beautify": "1.7.5",
-                "plugin-error": "1.0.1",
-                "through2": "2.0.3"
+                "deepmerge": "^2.1.1",
+                "detect-indent": "^5.0.0",
+                "js-beautify": "^1.7.5",
+                "plugin-error": "^1.0.1",
+                "through2": "^2.0.3"
             }
         },
         "gulp-remote-src-vscode": {
@@ -2354,11 +2354,11 @@
             "integrity": "sha512-/9vtSk9eI9DEWCqzGieglPqmx0WUQ9pwPHyHFpKmfxqdgqGJC2l0vFMdYs54hLdDsMDEZFLDL2J4ikjc4hQ5HQ==",
             "dev": true,
             "requires": {
-                "event-stream": "3.3.4",
-                "node.extend": "1.1.6",
-                "request": "2.87.0",
-                "through2": "2.0.3",
-                "vinyl": "2.2.0"
+                "event-stream": "^3.3.4",
+                "node.extend": "^1.1.2",
+                "request": "^2.79.0",
+                "through2": "^2.0.3",
+                "vinyl": "^2.0.1"
             },
             "dependencies": {
                 "clone": {
@@ -2401,11 +2401,11 @@
             "integrity": "sha1-uG/zSdgBzrVuHZ59x7vLS33uYAw=",
             "dev": true,
             "requires": {
-                "convert-source-map": "1.5.1",
-                "graceful-fs": "4.1.11",
-                "strip-bom": "2.0.0",
-                "through2": "2.0.3",
-                "vinyl": "1.2.0"
+                "convert-source-map": "^1.1.1",
+                "graceful-fs": "^4.1.2",
+                "strip-bom": "^2.0.0",
+                "through2": "^2.0.0",
+                "vinyl": "^1.0.0"
             },
             "dependencies": {
                 "vinyl": {
@@ -2414,8 +2414,8 @@
                     "integrity": "sha1-XIgDbPVl5d8FVYv8kR+GVt8hiIQ=",
                     "dev": true,
                     "requires": {
-                        "clone": "1.0.3",
-                        "clone-stats": "0.0.1",
+                        "clone": "^1.0.0",
+                        "clone-stats": "^0.0.1",
                         "replace-ext": "0.0.1"
                     }
                 }
@@ -2427,10 +2427,10 @@
             "integrity": "sha1-wWUyBzLRks5W/ZQnH/oSMjS/KuA=",
             "dev": true,
             "requires": {
-                "event-stream": "3.3.4",
-                "mkdirp": "0.5.1",
-                "queue": "3.1.0",
-                "vinyl-fs": "2.4.4"
+                "event-stream": "^3.3.1",
+                "mkdirp": "^0.5.1",
+                "queue": "^3.1.0",
+                "vinyl-fs": "^2.4.3"
             }
         },
         "gulp-untar": {
@@ -2439,11 +2439,11 @@
             "integrity": "sha512-0QfbCH2a1k2qkTLWPqTX+QO4qNsHn3kC546YhAP3/n0h+nvtyGITDuDrYBMDZeW4WnFijmkOvBWa5HshTic1tw==",
             "dev": true,
             "requires": {
-                "event-stream": "3.3.4",
-                "streamifier": "0.1.1",
-                "tar": "2.2.1",
-                "through2": "2.0.3",
-                "vinyl": "1.2.0"
+                "event-stream": "~3.3.4",
+                "streamifier": "~0.1.1",
+                "tar": "^2.2.1",
+                "through2": "~2.0.3",
+                "vinyl": "^1.2.0"
             },
             "dependencies": {
                 "vinyl": {
@@ -2452,8 +2452,8 @@
                     "integrity": "sha1-XIgDbPVl5d8FVYv8kR+GVt8hiIQ=",
                     "dev": true,
                     "requires": {
-                        "clone": "1.0.3",
-                        "clone-stats": "0.0.1",
+                        "clone": "^1.0.0",
+                        "clone-stats": "^0.0.1",
                         "replace-ext": "0.0.1"
                     }
                 }
@@ -2465,24 +2465,24 @@
             "integrity": "sha1-AFTh50RQLifATBh8PsxQXdVLu08=",
             "dev": true,
             "requires": {
-                "array-differ": "1.0.0",
-                "array-uniq": "1.0.3",
-                "beeper": "1.1.1",
-                "chalk": "1.1.3",
-                "dateformat": "2.2.0",
-                "fancy-log": "1.3.0",
-                "gulplog": "1.0.0",
-                "has-gulplog": "0.1.0",
-                "lodash._reescape": "3.0.0",
-                "lodash._reevaluate": "3.0.0",
-                "lodash._reinterpolate": "3.0.0",
-                "lodash.template": "3.6.2",
-                "minimist": "1.2.0",
-                "multipipe": "0.1.2",
-                "object-assign": "3.0.0",
+                "array-differ": "^1.0.0",
+                "array-uniq": "^1.0.2",
+                "beeper": "^1.0.0",
+                "chalk": "^1.0.0",
+                "dateformat": "^2.0.0",
+                "fancy-log": "^1.1.0",
+                "gulplog": "^1.0.0",
+                "has-gulplog": "^0.1.0",
+                "lodash._reescape": "^3.0.0",
+                "lodash._reevaluate": "^3.0.0",
+                "lodash._reinterpolate": "^3.0.0",
+                "lodash.template": "^3.0.0",
+                "minimist": "^1.1.0",
+                "multipipe": "^0.1.2",
+                "object-assign": "^3.0.0",
                 "replace-ext": "0.0.1",
-                "through2": "2.0.3",
-                "vinyl": "0.5.3"
+                "through2": "^2.0.0",
+                "vinyl": "^0.5.0"
             }
         },
         "gulp-vinyl-zip": {
@@ -2491,13 +2491,13 @@
             "integrity": "sha1-JOQGhdwFtxSZlSRQmeBZAmO+ja0=",
             "dev": true,
             "requires": {
-                "event-stream": "3.3.4",
-                "queue": "4.4.2",
-                "through2": "2.0.3",
-                "vinyl": "2.2.0",
-                "vinyl-fs": "2.4.4",
-                "yauzl": "2.10.0",
-                "yazl": "2.4.3"
+                "event-stream": "^3.3.1",
+                "queue": "^4.2.1",
+                "through2": "^2.0.3",
+                "vinyl": "^2.0.2",
+                "vinyl-fs": "^2.0.0",
+                "yauzl": "^2.2.1",
+                "yazl": "^2.2.1"
             },
             "dependencies": {
                 "clone": {
@@ -2518,7 +2518,7 @@
                     "integrity": "sha512-fSMRXbwhMwipcDZ08enW2vl+YDmAmhcNcr43sCJL8DIg+CFOsoRLG23ctxA+fwNk1w55SePSiS7oqQQSgQoVJQ==",
                     "dev": true,
                     "requires": {
-                        "inherits": "2.0.3"
+                        "inherits": "~2.0.0"
                     }
                 },
                 "replace-ext": {
@@ -2549,7 +2549,7 @@
             "integrity": "sha1-4oxNRdBey77YGDY86PnFkmIp/+U=",
             "dev": true,
             "requires": {
-                "glogg": "1.0.0"
+                "glogg": "^1.0.0"
             }
         },
         "handlebars": {
@@ -2558,10 +2558,10 @@
             "integrity": "sha1-Ywo13+ApS8KB7a5v/F0yn8eYLcw=",
             "dev": true,
             "requires": {
-                "async": "1.5.2",
-                "optimist": "0.6.1",
-                "source-map": "0.4.4",
-                "uglify-js": "2.8.29"
+                "async": "^1.4.0",
+                "optimist": "^0.6.1",
+                "source-map": "^0.4.4",
+                "uglify-js": "^2.6"
             },
             "dependencies": {
                 "source-map": {
@@ -2570,7 +2570,7 @@
                     "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
                     "dev": true,
                     "requires": {
-                        "amdefine": "1.0.1"
+                        "amdefine": ">=0.0.4"
                     }
                 }
             }
@@ -2586,10 +2586,10 @@
             "integrity": "sha1-zcvAgYgmWtEZtqWnyKtw7s+10n0=",
             "dev": true,
             "requires": {
-                "chalk": "1.1.3",
-                "commander": "2.12.2",
-                "is-my-json-valid": "2.16.1",
-                "pinkie-promise": "2.0.1"
+                "chalk": "^1.1.1",
+                "commander": "^2.9.0",
+                "is-my-json-valid": "^2.12.4",
+                "pinkie-promise": "^2.0.0"
             }
         },
         "has-ansi": {
@@ -2598,7 +2598,7 @@
             "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
             "dev": true,
             "requires": {
-                "ansi-regex": "2.1.1"
+                "ansi-regex": "^2.0.0"
             }
         },
         "has-flag": {
@@ -2613,7 +2613,7 @@
             "integrity": "sha1-ZBTIKRNpfaUVkDl9r7EvIpZ4Ec4=",
             "dev": true,
             "requires": {
-                "sparkles": "1.0.0"
+                "sparkles": "^1.0.0"
             }
         },
         "has-value": {
@@ -2622,9 +2622,9 @@
             "integrity": "sha1-GLKB2lhbHFxR3vJMkw7SmgvmsXc=",
             "dev": true,
             "requires": {
-                "get-value": "2.0.6",
-                "has-values": "1.0.0",
-                "isobject": "3.0.1"
+                "get-value": "^2.0.6",
+                "has-values": "^1.0.0",
+                "isobject": "^3.0.0"
             },
             "dependencies": {
                 "isobject": {
@@ -2641,8 +2641,8 @@
             "integrity": "sha1-lbC2P+whRmGab+V/51Yo1aOe/k8=",
             "dev": true,
             "requires": {
-                "is-number": "3.0.0",
-                "kind-of": "4.0.0"
+                "is-number": "^3.0.0",
+                "kind-of": "^4.0.0"
             },
             "dependencies": {
                 "is-number": {
@@ -2651,7 +2651,7 @@
                     "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
                     "dev": true,
                     "requires": {
-                        "kind-of": "3.2.2"
+                        "kind-of": "^3.0.2"
                     },
                     "dependencies": {
                         "kind-of": {
@@ -2660,7 +2660,7 @@
                             "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                             "dev": true,
                             "requires": {
-                                "is-buffer": "1.1.6"
+                                "is-buffer": "^1.1.5"
                             }
                         }
                     }
@@ -2671,7 +2671,7 @@
                     "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
                     "dev": true,
                     "requires": {
-                        "is-buffer": "1.1.6"
+                        "is-buffer": "^1.1.5"
                     }
                 }
             }
@@ -2682,10 +2682,10 @@
             "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
             "dev": true,
             "requires": {
-                "boom": "2.10.1",
-                "cryptiles": "2.0.5",
-                "hoek": "2.16.3",
-                "sntp": "1.0.9"
+                "boom": "2.x.x",
+                "cryptiles": "2.x.x",
+                "hoek": "2.x.x",
+                "sntp": "1.x.x"
             }
         },
         "he": {
@@ -2706,7 +2706,7 @@
             "integrity": "sha1-TCu8inWJmP7r9e1oWA921GdotLw=",
             "dev": true,
             "requires": {
-                "parse-passwd": "1.0.0"
+                "parse-passwd": "^1.0.0"
             }
         },
         "hosted-git-info": {
@@ -2721,9 +2721,9 @@
             "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
             "dev": true,
             "requires": {
-                "assert-plus": "0.2.0",
-                "jsprim": "1.4.1",
-                "sshpk": "1.13.1"
+                "assert-plus": "^0.2.0",
+                "jsprim": "^1.2.2",
+                "sshpk": "^1.7.0"
             }
         },
         "imul": {
@@ -2737,7 +2737,7 @@
             "integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=",
             "dev": true,
             "requires": {
-                "repeating": "2.0.1"
+                "repeating": "^2.0.0"
             }
         },
         "inflight": {
@@ -2746,8 +2746,8 @@
             "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
             "dev": true,
             "requires": {
-                "once": "1.4.0",
-                "wrappy": "1.0.2"
+                "once": "^1.3.0",
+                "wrappy": "1"
             }
         },
         "inherits": {
@@ -2780,8 +2780,8 @@
             "integrity": "sha512-dOWoqflvcydARa360Gvv18DZ/gRuHKi2NU/wU5X1ZFzdYfH29nkiNZsF3mp4OJ3H4yo9Mx8A/uAGNzpzPN3yBA==",
             "dev": true,
             "requires": {
-                "is-relative": "1.0.0",
-                "is-windows": "1.0.2"
+                "is-relative": "^1.0.0",
+                "is-windows": "^1.0.1"
             }
         },
         "is-accessor-descriptor": {
@@ -2790,7 +2790,7 @@
             "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
             "dev": true,
             "requires": {
-                "kind-of": "6.0.2"
+                "kind-of": "^6.0.0"
             },
             "dependencies": {
                 "kind-of": {
@@ -2819,7 +2819,7 @@
             "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
             "dev": true,
             "requires": {
-                "builtin-modules": "1.1.1"
+                "builtin-modules": "^1.0.0"
             }
         },
         "is-data-descriptor": {
@@ -2828,7 +2828,7 @@
             "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
             "dev": true,
             "requires": {
-                "kind-of": "6.0.2"
+                "kind-of": "^6.0.0"
             },
             "dependencies": {
                 "kind-of": {
@@ -2845,9 +2845,9 @@
             "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
             "dev": true,
             "requires": {
-                "is-accessor-descriptor": "1.0.0",
-                "is-data-descriptor": "1.0.0",
-                "kind-of": "6.0.2"
+                "is-accessor-descriptor": "^1.0.0",
+                "is-data-descriptor": "^1.0.0",
+                "kind-of": "^6.0.2"
             },
             "dependencies": {
                 "kind-of": {
@@ -2870,7 +2870,7 @@
             "integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
             "dev": true,
             "requires": {
-                "is-primitive": "2.0.0"
+                "is-primitive": "^2.0.0"
             }
         },
         "is-extendable": {
@@ -2891,7 +2891,7 @@
             "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
             "dev": true,
             "requires": {
-                "number-is-nan": "1.0.1"
+                "number-is-nan": "^1.0.0"
             }
         },
         "is-glob": {
@@ -2900,7 +2900,7 @@
             "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
             "dev": true,
             "requires": {
-                "is-extglob": "2.1.1"
+                "is-extglob": "^2.1.0"
             }
         },
         "is-my-json-valid": {
@@ -2909,10 +2909,10 @@
             "integrity": "sha512-ochPsqWS1WXj8ZnMIV0vnNXooaMhp7cyL4FMSIPKTtnV0Ha/T19G2b9kkhcNsabV9bxYkze7/aLZJb/bYuFduQ==",
             "dev": true,
             "requires": {
-                "generate-function": "2.0.0",
-                "generate-object-property": "1.2.0",
-                "jsonpointer": "4.0.1",
-                "xtend": "4.0.1"
+                "generate-function": "^2.0.0",
+                "generate-object-property": "^1.1.0",
+                "jsonpointer": "^4.0.0",
+                "xtend": "^4.0.0"
             }
         },
         "is-number": {
@@ -2921,7 +2921,7 @@
             "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
             "dev": true,
             "requires": {
-                "kind-of": "3.2.2"
+                "kind-of": "^3.0.2"
             }
         },
         "is-obj": {
@@ -2936,7 +2936,7 @@
             "integrity": "sha512-OTiixgpZAT1M4NHgS5IguFp/Vz2VI3U7Goh4/HA1adtwyLtSBrxYlcSYkhpAE07s4fKEcjrFxyvtQBND4vFQyQ==",
             "dev": true,
             "requires": {
-                "is-number": "4.0.0"
+                "is-number": "^4.0.0"
             },
             "dependencies": {
                 "is-number": {
@@ -2959,7 +2959,7 @@
             "integrity": "sha1-ZHdYK4IU1gI0YJRWcAO+ip6sBNw=",
             "dev": true,
             "requires": {
-                "is-path-inside": "1.0.1"
+                "is-path-inside": "^1.0.0"
             }
         },
         "is-path-inside": {
@@ -2968,7 +2968,7 @@
             "integrity": "sha1-jvW33lBDej/cprToZe96pVy0gDY=",
             "dev": true,
             "requires": {
-                "path-is-inside": "1.0.2"
+                "path-is-inside": "^1.0.1"
             }
         },
         "is-plain-object": {
@@ -2977,7 +2977,7 @@
             "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
             "dev": true,
             "requires": {
-                "isobject": "3.0.1"
+                "isobject": "^3.0.1"
             },
             "dependencies": {
                 "isobject": {
@@ -3012,7 +3012,7 @@
             "integrity": "sha512-Kw/ReK0iqwKeu0MITLFuj0jbPAmEiOsIwyIXvvbfa6QfmN9pkD1M+8pdk7Rl/dTKbH34/XBFMbgD4iMJhLQbGA==",
             "dev": true,
             "requires": {
-                "is-unc-path": "1.0.0"
+                "is-unc-path": "^1.0.0"
             }
         },
         "is-stream": {
@@ -3032,7 +3032,7 @@
             "integrity": "sha512-mrGpVd0fs7WWLfVsStvgF6iEJnbjDFZh9/emhRDcGWTduTfNHd9CHeUwH3gYIjdbwo4On6hunkztwOaAw0yllQ==",
             "dev": true,
             "requires": {
-                "unc-path-regex": "0.1.2"
+                "unc-path-regex": "^0.1.2"
             }
         },
         "is-utf8": {
@@ -3085,20 +3085,20 @@
             "integrity": "sha1-ZcfXPUxNqE1POsMQuRj7C4Azczs=",
             "dev": true,
             "requires": {
-                "abbrev": "1.0.9",
-                "async": "1.5.2",
-                "escodegen": "1.8.1",
-                "esprima": "2.7.3",
-                "glob": "5.0.15",
-                "handlebars": "4.0.11",
-                "js-yaml": "3.12.0",
-                "mkdirp": "0.5.1",
-                "nopt": "3.0.6",
-                "once": "1.4.0",
-                "resolve": "1.1.7",
-                "supports-color": "3.2.3",
-                "which": "1.3.0",
-                "wordwrap": "1.0.0"
+                "abbrev": "1.0.x",
+                "async": "1.x",
+                "escodegen": "1.8.x",
+                "esprima": "2.7.x",
+                "glob": "^5.0.15",
+                "handlebars": "^4.0.1",
+                "js-yaml": "3.x",
+                "mkdirp": "0.5.x",
+                "nopt": "3.x",
+                "once": "1.x",
+                "resolve": "1.1.x",
+                "supports-color": "^3.1.0",
+                "which": "^1.1.1",
+                "wordwrap": "^1.0.0"
             },
             "dependencies": {
                 "esprima": {
@@ -3113,11 +3113,11 @@
                     "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
                     "dev": true,
                     "requires": {
-                        "inflight": "1.0.6",
-                        "inherits": "2.0.3",
-                        "minimatch": "3.0.4",
-                        "once": "1.4.0",
-                        "path-is-absolute": "1.0.1"
+                        "inflight": "^1.0.4",
+                        "inherits": "2",
+                        "minimatch": "2 || 3",
+                        "once": "^1.3.0",
+                        "path-is-absolute": "^1.0.0"
                     }
                 },
                 "has-flag": {
@@ -3132,7 +3132,7 @@
                     "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
                     "dev": true,
                     "requires": {
-                        "has-flag": "1.0.0"
+                        "has-flag": "^1.0.0"
                     }
                 }
             }
@@ -3143,10 +3143,10 @@
             "integrity": "sha512-9OhfAqGOrD7hoQBLJMTA+BKuKmoEtTJXzZ7WDF/9gvjtey1koVLuZqIY6c51aPDjbNdNtIXAkiWKVhziawE9Og==",
             "dev": true,
             "requires": {
-                "config-chain": "1.1.11",
-                "editorconfig": "0.13.3",
-                "mkdirp": "0.5.1",
-                "nopt": "3.0.6"
+                "config-chain": "~1.1.5",
+                "editorconfig": "^0.13.2",
+                "mkdirp": "~0.5.0",
+                "nopt": "~3.0.1"
             }
         },
         "js-yaml": {
@@ -3154,8 +3154,8 @@
             "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.12.0.tgz",
             "integrity": "sha512-PIt2cnwmPfL4hKNwqeiuz4bKfnzHTBv6HyVgjahA6mPLwPDzjDWrplJBMjHUFxku/N3FlmrbyPclad+I+4mJ3A==",
             "requires": {
-                "argparse": "1.0.9",
-                "esprima": "4.0.1"
+                "argparse": "^1.0.7",
+                "esprima": "^4.0.0"
             }
         },
         "jsbn": {
@@ -3180,7 +3180,7 @@
             "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
             "dev": true,
             "requires": {
-                "jsonify": "0.0.0"
+                "jsonify": "~0.0.0"
             }
         },
         "json-stringify-safe": {
@@ -3229,7 +3229,7 @@
             "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
             "dev": true,
             "requires": {
-                "is-buffer": "1.1.6"
+                "is-buffer": "^1.1.5"
             }
         },
         "lazy-cache": {
@@ -3245,7 +3245,7 @@
             "integrity": "sha1-9plf4PggOS9hOWvolGJAe7dxaOQ=",
             "dev": true,
             "requires": {
-                "readable-stream": "2.3.3"
+                "readable-stream": "^2.0.5"
             }
         },
         "lcov-parse": {
@@ -3260,8 +3260,8 @@
             "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
             "dev": true,
             "requires": {
-                "prelude-ls": "1.1.2",
-                "type-check": "0.3.2"
+                "prelude-ls": "~1.1.2",
+                "type-check": "~0.3.2"
             }
         },
         "liftoff": {
@@ -3270,14 +3270,14 @@
             "integrity": "sha1-IAkpG7Mc6oYbvxCnwVooyvdcMew=",
             "dev": true,
             "requires": {
-                "extend": "3.0.1",
-                "findup-sync": "2.0.0",
-                "fined": "1.1.0",
-                "flagged-respawn": "1.0.0",
-                "is-plain-object": "2.0.4",
-                "object.map": "1.0.1",
-                "rechoir": "0.6.2",
-                "resolve": "1.1.7"
+                "extend": "^3.0.0",
+                "findup-sync": "^2.0.0",
+                "fined": "^1.0.1",
+                "flagged-respawn": "^1.0.0",
+                "is-plain-object": "^2.0.4",
+                "object.map": "^1.0.0",
+                "rechoir": "^0.6.2",
+                "resolve": "^1.1.7"
             }
         },
         "load-json-file": {
@@ -3286,17 +3286,18 @@
             "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
             "dev": true,
             "requires": {
-                "graceful-fs": "4.1.11",
-                "parse-json": "2.2.0",
-                "pify": "2.3.0",
-                "pinkie-promise": "2.0.1",
-                "strip-bom": "2.0.0"
+                "graceful-fs": "^4.1.2",
+                "parse-json": "^2.2.0",
+                "pify": "^2.0.0",
+                "pinkie-promise": "^2.0.0",
+                "strip-bom": "^2.0.0"
             }
         },
         "lodash": {
             "version": "4.17.4",
             "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
-            "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4="
+            "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
+            "dev": true
         },
         "lodash._basecopy": {
             "version": "3.0.1",
@@ -3358,7 +3359,7 @@
             "integrity": "sha1-mV7g3BjBtIzJLv+ucaEKq1tIdpg=",
             "dev": true,
             "requires": {
-                "lodash._root": "3.0.1"
+                "lodash._root": "^3.0.0"
             }
         },
         "lodash.isarguments": {
@@ -3385,9 +3386,9 @@
             "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
             "dev": true,
             "requires": {
-                "lodash._getnative": "3.9.1",
-                "lodash.isarguments": "3.1.0",
-                "lodash.isarray": "3.0.4"
+                "lodash._getnative": "^3.0.0",
+                "lodash.isarguments": "^3.0.0",
+                "lodash.isarray": "^3.0.0"
             }
         },
         "lodash.restparam": {
@@ -3402,15 +3403,15 @@
             "integrity": "sha1-+M3sxhaaJVvpCYrosMU9N4kx0U8=",
             "dev": true,
             "requires": {
-                "lodash._basecopy": "3.0.1",
-                "lodash._basetostring": "3.0.1",
-                "lodash._basevalues": "3.0.0",
-                "lodash._isiterateecall": "3.0.9",
-                "lodash._reinterpolate": "3.0.0",
-                "lodash.escape": "3.2.0",
-                "lodash.keys": "3.1.2",
-                "lodash.restparam": "3.6.1",
-                "lodash.templatesettings": "3.1.1"
+                "lodash._basecopy": "^3.0.0",
+                "lodash._basetostring": "^3.0.0",
+                "lodash._basevalues": "^3.0.0",
+                "lodash._isiterateecall": "^3.0.0",
+                "lodash._reinterpolate": "^3.0.0",
+                "lodash.escape": "^3.0.0",
+                "lodash.keys": "^3.0.0",
+                "lodash.restparam": "^3.0.0",
+                "lodash.templatesettings": "^3.0.0"
             }
         },
         "lodash.templatesettings": {
@@ -3419,8 +3420,8 @@
             "integrity": "sha1-+zB4RHU7Zrnxr6VOJix0UwfbqOU=",
             "dev": true,
             "requires": {
-                "lodash._reinterpolate": "3.0.0",
-                "lodash.escape": "3.2.0"
+                "lodash._reinterpolate": "^3.0.0",
+                "lodash.escape": "^3.0.0"
             }
         },
         "log-driver": {
@@ -3441,8 +3442,8 @@
             "integrity": "sha1-W0b4AUft7leIcPCG0Eghz5mOVR8=",
             "dev": true,
             "requires": {
-                "currently-unhandled": "0.4.1",
-                "signal-exit": "3.0.2"
+                "currently-unhandled": "^0.4.1",
+                "signal-exit": "^3.0.0"
             }
         },
         "lru-cache": {
@@ -3457,7 +3458,7 @@
             "integrity": "sha1-V7713IXSOSO6I3ZzJNjo+PPZaUs=",
             "dev": true,
             "requires": {
-                "kind-of": "3.2.2"
+                "kind-of": "^3.1.0"
             }
         },
         "map-cache": {
@@ -3484,7 +3485,7 @@
             "integrity": "sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=",
             "dev": true,
             "requires": {
-                "object-visit": "1.0.1"
+                "object-visit": "^1.0.0"
             }
         },
         "math-random": {
@@ -3499,16 +3500,16 @@
             "integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
             "dev": true,
             "requires": {
-                "camelcase-keys": "2.1.0",
-                "decamelize": "1.2.0",
-                "loud-rejection": "1.6.0",
-                "map-obj": "1.0.1",
-                "minimist": "1.2.0",
-                "normalize-package-data": "2.4.0",
-                "object-assign": "4.1.1",
-                "read-pkg-up": "1.0.1",
-                "redent": "1.0.0",
-                "trim-newlines": "1.0.0"
+                "camelcase-keys": "^2.0.0",
+                "decamelize": "^1.1.2",
+                "loud-rejection": "^1.0.0",
+                "map-obj": "^1.0.1",
+                "minimist": "^1.1.3",
+                "normalize-package-data": "^2.3.4",
+                "object-assign": "^4.0.1",
+                "read-pkg-up": "^1.0.1",
+                "redent": "^1.0.0",
+                "trim-newlines": "^1.0.0"
             },
             "dependencies": {
                 "object-assign": {
@@ -3525,7 +3526,7 @@
             "integrity": "sha1-QEEgLVCKNCugAXQAjfDCUbjBNeE=",
             "dev": true,
             "requires": {
-                "readable-stream": "2.3.3"
+                "readable-stream": "^2.0.1"
             }
         },
         "micromatch": {
@@ -3534,19 +3535,19 @@
             "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
             "dev": true,
             "requires": {
-                "arr-diff": "2.0.0",
-                "array-unique": "0.2.1",
-                "braces": "1.8.5",
-                "expand-brackets": "0.1.5",
-                "extglob": "0.3.2",
-                "filename-regex": "2.0.1",
-                "is-extglob": "1.0.0",
-                "is-glob": "2.0.1",
-                "kind-of": "3.2.2",
-                "normalize-path": "2.1.1",
-                "object.omit": "2.0.1",
-                "parse-glob": "3.0.4",
-                "regex-cache": "0.4.4"
+                "arr-diff": "^2.0.0",
+                "array-unique": "^0.2.1",
+                "braces": "^1.8.2",
+                "expand-brackets": "^0.1.4",
+                "extglob": "^0.3.1",
+                "filename-regex": "^2.0.0",
+                "is-extglob": "^1.0.0",
+                "is-glob": "^2.0.1",
+                "kind-of": "^3.0.2",
+                "normalize-path": "^2.0.1",
+                "object.omit": "^2.0.0",
+                "parse-glob": "^3.0.4",
+                "regex-cache": "^0.4.2"
             },
             "dependencies": {
                 "arr-diff": {
@@ -3555,7 +3556,7 @@
                     "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
                     "dev": true,
                     "requires": {
-                        "arr-flatten": "1.1.0"
+                        "arr-flatten": "^1.0.1"
                     }
                 },
                 "is-extglob": {
@@ -3570,7 +3571,7 @@
                     "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
                     "dev": true,
                     "requires": {
-                        "is-extglob": "1.0.0"
+                        "is-extglob": "^1.0.0"
                     }
                 }
             }
@@ -3585,7 +3586,7 @@
             "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.17.tgz",
             "integrity": "sha1-Cdejk/A+mVp5+K+Fe3Cp4KsWVXo=",
             "requires": {
-                "mime-db": "1.30.0"
+                "mime-db": "~1.30.0"
             }
         },
         "minimatch": {
@@ -3594,7 +3595,7 @@
             "integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM=",
             "dev": true,
             "requires": {
-                "brace-expansion": "1.1.8"
+                "brace-expansion": "^1.1.7"
             }
         },
         "minimist": {
@@ -3609,8 +3610,8 @@
             "integrity": "sha512-8ZItLHeEgaqEvd5lYBXfm4EZSFCX29Jb9K+lAHhDKzReKBQKj3R+7NOF6tjqYi9t4oI8VUfaWITJQm86wnXGNQ==",
             "dev": true,
             "requires": {
-                "for-in": "1.0.2",
-                "is-extendable": "1.0.1"
+                "for-in": "^1.0.2",
+                "is-extendable": "^1.0.1"
             },
             "dependencies": {
                 "is-extendable": {
@@ -3619,7 +3620,7 @@
                     "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
                     "dev": true,
                     "requires": {
-                        "is-plain-object": "2.0.4"
+                        "is-plain-object": "^2.0.4"
                     }
                 }
             }
@@ -3671,7 +3672,7 @@
                     "integrity": "sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==",
                     "dev": true,
                     "requires": {
-                        "has-flag": "2.0.0"
+                        "has-flag": "^2.0.0"
                     }
                 }
             }
@@ -3688,10 +3689,10 @@
             "integrity": "sha1-nHkGoi+0wCkZ4vX3UWG0zb1LKis=",
             "dev": true,
             "requires": {
-                "array-differ": "1.0.0",
-                "array-union": "1.0.2",
-                "arrify": "1.0.1",
-                "minimatch": "3.0.4"
+                "array-differ": "^1.0.0",
+                "array-union": "^1.0.1",
+                "arrify": "^1.0.0",
+                "minimatch": "^3.0.0"
             }
         },
         "multipipe": {
@@ -3708,9 +3709,9 @@
             "resolved": "https://registry.npmjs.org/murmur-32/-/murmur-32-0.1.0.tgz",
             "integrity": "sha1-waedT8X6vwQFdJ0K/3fEFAIFWGE=",
             "requires": {
-                "array-buffer-from-string": "0.1.0",
-                "fmix": "0.1.0",
-                "imul": "1.0.1"
+                "array-buffer-from-string": "^0.1.0",
+                "fmix": "^0.1.0",
+                "imul": "^1.0.0"
             }
         },
         "nanomatch": {
@@ -3719,18 +3720,18 @@
             "integrity": "sha512-n8R9bS8yQ6eSXaV6jHUpKzD8gLsin02w1HSFiegwrs9E098Ylhw5jdyKPaYqvHknHaSCKTPp7C8dGCQ0q9koXA==",
             "dev": true,
             "requires": {
-                "arr-diff": "4.0.0",
-                "array-unique": "0.3.2",
-                "define-property": "2.0.2",
-                "extend-shallow": "3.0.2",
-                "fragment-cache": "0.2.1",
-                "is-odd": "2.0.0",
-                "is-windows": "1.0.2",
-                "kind-of": "6.0.2",
-                "object.pick": "1.3.0",
-                "regex-not": "1.0.2",
-                "snapdragon": "0.8.1",
-                "to-regex": "3.0.2"
+                "arr-diff": "^4.0.0",
+                "array-unique": "^0.3.2",
+                "define-property": "^2.0.2",
+                "extend-shallow": "^3.0.2",
+                "fragment-cache": "^0.2.1",
+                "is-odd": "^2.0.0",
+                "is-windows": "^1.0.2",
+                "kind-of": "^6.0.2",
+                "object.pick": "^1.3.0",
+                "regex-not": "^1.0.0",
+                "snapdragon": "^0.8.1",
+                "to-regex": "^3.0.1"
             },
             "dependencies": {
                 "arr-diff": {
@@ -3751,8 +3752,8 @@
                     "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
                     "dev": true,
                     "requires": {
-                        "assign-symbols": "1.0.0",
-                        "is-extendable": "1.0.1"
+                        "assign-symbols": "^1.0.0",
+                        "is-extendable": "^1.0.1"
                     }
                 },
                 "is-extendable": {
@@ -3761,7 +3762,7 @@
                     "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
                     "dev": true,
                     "requires": {
-                        "is-plain-object": "2.0.4"
+                        "is-plain-object": "^2.0.4"
                     }
                 },
                 "kind-of": {
@@ -3784,7 +3785,7 @@
             "integrity": "sha1-p7iCyC1sk6SGOlUEvV3o7IYli5Y=",
             "dev": true,
             "requires": {
-                "is": "3.2.1"
+                "is": "^3.1.0"
             }
         },
         "nopt": {
@@ -3793,7 +3794,7 @@
             "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
             "dev": true,
             "requires": {
-                "abbrev": "1.0.9"
+                "abbrev": "1"
             }
         },
         "normalize-package-data": {
@@ -3802,10 +3803,10 @@
             "integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
             "dev": true,
             "requires": {
-                "hosted-git-info": "2.5.0",
-                "is-builtin-module": "1.0.0",
-                "semver": "5.4.1",
-                "validate-npm-package-license": "3.0.1"
+                "hosted-git-info": "^2.1.4",
+                "is-builtin-module": "^1.0.0",
+                "semver": "2 || 3 || 4 || 5",
+                "validate-npm-package-license": "^3.0.1"
             }
         },
         "normalize-path": {
@@ -3814,7 +3815,7 @@
             "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
             "dev": true,
             "requires": {
-                "remove-trailing-separator": "1.1.0"
+                "remove-trailing-separator": "^1.0.1"
             }
         },
         "number-is-nan": {
@@ -3840,9 +3841,9 @@
             "integrity": "sha1-fn2Fi3gb18mRpBupde04EnVOmYw=",
             "dev": true,
             "requires": {
-                "copy-descriptor": "0.1.1",
-                "define-property": "0.2.5",
-                "kind-of": "3.2.2"
+                "copy-descriptor": "^0.1.0",
+                "define-property": "^0.2.5",
+                "kind-of": "^3.0.3"
             },
             "dependencies": {
                 "define-property": {
@@ -3851,7 +3852,7 @@
                     "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
                     "dev": true,
                     "requires": {
-                        "is-descriptor": "0.1.6"
+                        "is-descriptor": "^0.1.0"
                     }
                 },
                 "is-accessor-descriptor": {
@@ -3860,7 +3861,7 @@
                     "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
                     "dev": true,
                     "requires": {
-                        "kind-of": "3.2.2"
+                        "kind-of": "^3.0.2"
                     }
                 },
                 "is-data-descriptor": {
@@ -3869,7 +3870,7 @@
                     "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
                     "dev": true,
                     "requires": {
-                        "kind-of": "3.2.2"
+                        "kind-of": "^3.0.2"
                     }
                 },
                 "is-descriptor": {
@@ -3878,9 +3879,9 @@
                     "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
                     "dev": true,
                     "requires": {
-                        "is-accessor-descriptor": "0.1.6",
-                        "is-data-descriptor": "0.1.4",
-                        "kind-of": "5.1.0"
+                        "is-accessor-descriptor": "^0.1.6",
+                        "is-data-descriptor": "^0.1.4",
+                        "kind-of": "^5.0.0"
                     },
                     "dependencies": {
                         "kind-of": {
@@ -3899,7 +3900,7 @@
             "integrity": "sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=",
             "dev": true,
             "requires": {
-                "isobject": "3.0.1"
+                "isobject": "^3.0.0"
             },
             "dependencies": {
                 "isobject": {
@@ -3916,10 +3917,10 @@
             "integrity": "sha1-On+GgzS0B96gbaFtiNXNKeQ1/s8=",
             "dev": true,
             "requires": {
-                "array-each": "1.0.1",
-                "array-slice": "1.1.0",
-                "for-own": "1.0.0",
-                "isobject": "3.0.1"
+                "array-each": "^1.0.1",
+                "array-slice": "^1.0.0",
+                "for-own": "^1.0.0",
+                "isobject": "^3.0.0"
             },
             "dependencies": {
                 "for-own": {
@@ -3928,7 +3929,7 @@
                     "integrity": "sha1-xjMy9BXO3EsE2/5wz4NklMU8tEs=",
                     "dev": true,
                     "requires": {
-                        "for-in": "1.0.2"
+                        "for-in": "^1.0.1"
                     }
                 },
                 "isobject": {
@@ -3945,8 +3946,8 @@
             "integrity": "sha1-z4Plncj8wK1fQlDh94s7gb2AHTc=",
             "dev": true,
             "requires": {
-                "for-own": "1.0.0",
-                "make-iterator": "1.0.0"
+                "for-own": "^1.0.0",
+                "make-iterator": "^1.0.0"
             },
             "dependencies": {
                 "for-own": {
@@ -3955,7 +3956,7 @@
                     "integrity": "sha1-xjMy9BXO3EsE2/5wz4NklMU8tEs=",
                     "dev": true,
                     "requires": {
-                        "for-in": "1.0.2"
+                        "for-in": "^1.0.1"
                     }
                 }
             }
@@ -3966,8 +3967,8 @@
             "integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
             "dev": true,
             "requires": {
-                "for-own": "0.1.5",
-                "is-extendable": "0.1.1"
+                "for-own": "^0.1.4",
+                "is-extendable": "^0.1.1"
             }
         },
         "object.pick": {
@@ -3976,7 +3977,7 @@
             "integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
             "dev": true,
             "requires": {
-                "isobject": "3.0.1"
+                "isobject": "^3.0.1"
             },
             "dependencies": {
                 "isobject": {
@@ -3993,7 +3994,7 @@
             "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
             "dev": true,
             "requires": {
-                "wrappy": "1.0.2"
+                "wrappy": "1"
             }
         },
         "optimist": {
@@ -4002,8 +4003,8 @@
             "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
             "dev": true,
             "requires": {
-                "minimist": "0.0.10",
-                "wordwrap": "0.0.3"
+                "minimist": "~0.0.1",
+                "wordwrap": "~0.0.2"
             },
             "dependencies": {
                 "minimist": {
@@ -4026,12 +4027,12 @@
             "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
             "dev": true,
             "requires": {
-                "deep-is": "0.1.3",
-                "fast-levenshtein": "2.0.6",
-                "levn": "0.3.0",
-                "prelude-ls": "1.1.2",
-                "type-check": "0.3.2",
-                "wordwrap": "1.0.0"
+                "deep-is": "~0.1.3",
+                "fast-levenshtein": "~2.0.4",
+                "levn": "~0.3.0",
+                "prelude-ls": "~1.1.2",
+                "type-check": "~0.3.2",
+                "wordwrap": "~1.0.0"
             }
         },
         "orchestrator": {
@@ -4040,9 +4041,9 @@
             "integrity": "sha1-FOfp4nZPcxX7rBhOUGx6pt+UrX4=",
             "dev": true,
             "requires": {
-                "end-of-stream": "0.1.5",
-                "sequencify": "0.0.7",
-                "stream-consume": "0.1.1"
+                "end-of-stream": "~0.1.5",
+                "sequencify": "~0.0.7",
+                "stream-consume": "~0.1.0"
             },
             "dependencies": {
                 "end-of-stream": {
@@ -4051,7 +4052,7 @@
                     "integrity": "sha1-jhdyBsPICDfYVjLouTWd/osvbq8=",
                     "dev": true,
                     "requires": {
-                        "once": "1.3.3"
+                        "once": "~1.3.0"
                     }
                 },
                 "once": {
@@ -4060,7 +4061,7 @@
                     "integrity": "sha1-suJhVXzkwxTsgwTz+oJmPkKXyiA=",
                     "dev": true,
                     "requires": {
-                        "wrappy": "1.0.2"
+                        "wrappy": "1"
                     }
                 }
             }
@@ -4071,8 +4072,8 @@
             "integrity": "sha1-cTfmmzKYuzQiR6G77jiByA4v14s=",
             "dev": true,
             "requires": {
-                "is-stream": "1.1.0",
-                "readable-stream": "2.3.3"
+                "is-stream": "^1.0.1",
+                "readable-stream": "^2.0.1"
             }
         },
         "os-homedir": {
@@ -4093,9 +4094,9 @@
             "integrity": "sha1-pjISf1Oq89FYdvWHLz/6x2PWyJE=",
             "dev": true,
             "requires": {
-                "is-absolute": "1.0.0",
-                "map-cache": "0.2.2",
-                "path-root": "0.1.1"
+                "is-absolute": "^1.0.0",
+                "map-cache": "^0.2.0",
+                "path-root": "^0.1.1"
             }
         },
         "parse-glob": {
@@ -4104,10 +4105,10 @@
             "integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
             "dev": true,
             "requires": {
-                "glob-base": "0.3.0",
-                "is-dotfile": "1.0.3",
-                "is-extglob": "1.0.0",
-                "is-glob": "2.0.1"
+                "glob-base": "^0.3.0",
+                "is-dotfile": "^1.0.0",
+                "is-extglob": "^1.0.0",
+                "is-glob": "^2.0.0"
             },
             "dependencies": {
                 "is-extglob": {
@@ -4122,7 +4123,7 @@
                     "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
                     "dev": true,
                     "requires": {
-                        "is-extglob": "1.0.0"
+                        "is-extglob": "^1.0.0"
                     }
                 }
             }
@@ -4133,7 +4134,7 @@
             "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
             "dev": true,
             "requires": {
-                "error-ex": "1.3.1"
+                "error-ex": "^1.2.0"
             }
         },
         "parse-passwd": {
@@ -4160,7 +4161,7 @@
             "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
             "dev": true,
             "requires": {
-                "pinkie-promise": "2.0.1"
+                "pinkie-promise": "^2.0.0"
             }
         },
         "path-is-absolute": {
@@ -4181,7 +4182,7 @@
             "integrity": "sha1-mkpoFMrBwM1zNgqV8yCDyOpHRbc=",
             "dev": true,
             "requires": {
-                "path-root-regex": "0.1.2"
+                "path-root-regex": "^0.1.0"
             }
         },
         "path-root-regex": {
@@ -4196,9 +4197,9 @@
             "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
             "dev": true,
             "requires": {
-                "graceful-fs": "4.1.11",
-                "pify": "2.3.0",
-                "pinkie-promise": "2.0.1"
+                "graceful-fs": "^4.1.2",
+                "pify": "^2.0.0",
+                "pinkie-promise": "^2.0.0"
             }
         },
         "pause-stream": {
@@ -4207,7 +4208,7 @@
             "integrity": "sha1-/lo0sMvOErWqaitAPuLnO2AvFEU=",
             "dev": true,
             "requires": {
-                "through": "2.3.8"
+                "through": "~2.3"
             }
         },
         "pend": {
@@ -4239,7 +4240,7 @@
             "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
             "dev": true,
             "requires": {
-                "pinkie": "2.0.4"
+                "pinkie": "^2.0.0"
             }
         },
         "plugin-error": {
@@ -4248,10 +4249,10 @@
             "integrity": "sha512-L1zP0dk7vGweZME2i+EeakvUNqSrdiI3F91TwEoYiGrAfUXmVv6fJIq4g82PAXxNsWOp0J7ZqQy/3Szz0ajTxA==",
             "dev": true,
             "requires": {
-                "ansi-colors": "1.1.0",
-                "arr-diff": "4.0.0",
-                "arr-union": "3.1.0",
-                "extend-shallow": "3.0.2"
+                "ansi-colors": "^1.0.1",
+                "arr-diff": "^4.0.0",
+                "arr-union": "^3.1.0",
+                "extend-shallow": "^3.0.2"
             },
             "dependencies": {
                 "extend-shallow": {
@@ -4260,8 +4261,8 @@
                     "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
                     "dev": true,
                     "requires": {
-                        "assign-symbols": "1.0.0",
-                        "is-extendable": "1.0.1"
+                        "assign-symbols": "^1.0.0",
+                        "is-extendable": "^1.0.1"
                     }
                 },
                 "is-extendable": {
@@ -4270,7 +4271,7 @@
                     "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
                     "dev": true,
                     "requires": {
-                        "is-plain-object": "2.0.4"
+                        "is-plain-object": "^2.0.4"
                     }
                 }
             }
@@ -4346,7 +4347,7 @@
             "integrity": "sha1-bEnQHwCeIlZ4h4nyv/rGuLmZBYU=",
             "dev": true,
             "requires": {
-                "inherits": "2.0.3"
+                "inherits": "~2.0.0"
             }
         },
         "random-path": {
@@ -4354,8 +4355,8 @@
             "resolved": "https://registry.npmjs.org/random-path/-/random-path-0.1.1.tgz",
             "integrity": "sha1-+PTTb3WhNMoV/TnH11BfvxY7Y0w=",
             "requires": {
-                "base32-encode": "0.1.1",
-                "murmur-32": "0.1.0"
+                "base32-encode": "^0.1.0",
+                "murmur-32": "^0.1.0"
             }
         },
         "randomatic": {
@@ -4364,9 +4365,9 @@
             "integrity": "sha512-VdxFOIEY3mNO5PtSRkkle/hPJDHvQhK21oa73K4yAc9qmp6N429gAyF1gZMOTMeS0/AYzaV/2Trcef+NaIonSA==",
             "dev": true,
             "requires": {
-                "is-number": "4.0.0",
-                "kind-of": "6.0.2",
-                "math-random": "1.0.1"
+                "is-number": "^4.0.0",
+                "kind-of": "^6.0.0",
+                "math-random": "^1.0.1"
             },
             "dependencies": {
                 "is-number": {
@@ -4389,9 +4390,9 @@
             "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
             "dev": true,
             "requires": {
-                "load-json-file": "1.1.0",
-                "normalize-package-data": "2.4.0",
-                "path-type": "1.1.0"
+                "load-json-file": "^1.0.0",
+                "normalize-package-data": "^2.3.2",
+                "path-type": "^1.0.0"
             }
         },
         "read-pkg-up": {
@@ -4400,8 +4401,8 @@
             "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
             "dev": true,
             "requires": {
-                "find-up": "1.1.2",
-                "read-pkg": "1.1.0"
+                "find-up": "^1.0.0",
+                "read-pkg": "^1.0.0"
             }
         },
         "readable-stream": {
@@ -4410,13 +4411,13 @@
             "integrity": "sha1-No8lEtefnUb9/HE0mueHi7weuVw=",
             "dev": true,
             "requires": {
-                "core-util-is": "1.0.2",
-                "inherits": "2.0.3",
-                "isarray": "1.0.0",
-                "process-nextick-args": "1.0.7",
-                "safe-buffer": "5.1.1",
-                "string_decoder": "1.0.3",
-                "util-deprecate": "1.0.2"
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.3",
+                "isarray": "~1.0.0",
+                "process-nextick-args": "~1.0.6",
+                "safe-buffer": "~5.1.1",
+                "string_decoder": "~1.0.3",
+                "util-deprecate": "~1.0.1"
             }
         },
         "rechoir": {
@@ -4425,7 +4426,7 @@
             "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
             "dev": true,
             "requires": {
-                "resolve": "1.1.7"
+                "resolve": "^1.1.6"
             }
         },
         "redent": {
@@ -4434,8 +4435,8 @@
             "integrity": "sha1-z5Fqsf1fHxbfsggi3W7H9zDCr94=",
             "dev": true,
             "requires": {
-                "indent-string": "2.1.0",
-                "strip-indent": "1.0.1"
+                "indent-string": "^2.1.0",
+                "strip-indent": "^1.0.1"
             }
         },
         "regex-cache": {
@@ -4444,7 +4445,7 @@
             "integrity": "sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==",
             "dev": true,
             "requires": {
-                "is-equal-shallow": "0.1.3"
+                "is-equal-shallow": "^0.1.3"
             }
         },
         "regex-not": {
@@ -4453,8 +4454,8 @@
             "integrity": "sha512-J6SDjUgDxQj5NusnOtdFxDwN/+HWykR8GELwctJ7mdqhcyy1xEc4SRFHUXvxTp661YaVKAjfRLZ9cCqS6tn32A==",
             "dev": true,
             "requires": {
-                "extend-shallow": "3.0.2",
-                "safe-regex": "1.1.0"
+                "extend-shallow": "^3.0.2",
+                "safe-regex": "^1.1.0"
             },
             "dependencies": {
                 "extend-shallow": {
@@ -4463,8 +4464,8 @@
                     "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
                     "dev": true,
                     "requires": {
-                        "assign-symbols": "1.0.0",
-                        "is-extendable": "1.0.1"
+                        "assign-symbols": "^1.0.0",
+                        "is-extendable": "^1.0.1"
                     }
                 },
                 "is-extendable": {
@@ -4473,7 +4474,7 @@
                     "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
                     "dev": true,
                     "requires": {
-                        "is-plain-object": "2.0.4"
+                        "is-plain-object": "^2.0.4"
                     }
                 }
             }
@@ -4487,7 +4488,7 @@
                 "amdefine": "1.0.0",
                 "gulp-util": "3.0.7",
                 "istanbul": "0.4.3",
-                "source-map": "0.6.1",
+                "source-map": ">=0.5.6",
                 "through2": "2.0.1"
             },
             "dependencies": {
@@ -4503,8 +4504,8 @@
                     "integrity": "sha1-nxJLZ1lMk3/3BpMuSmQsyo27/uk=",
                     "dev": true,
                     "requires": {
-                        "get-stdin": "4.0.1",
-                        "meow": "3.7.0"
+                        "get-stdin": "^4.0.1",
+                        "meow": "^3.3.0"
                     }
                 },
                 "esprima": {
@@ -4519,24 +4520,24 @@
                     "integrity": "sha1-eJJcS4+LSQBawBoBHFV+YhiUHLs=",
                     "dev": true,
                     "requires": {
-                        "array-differ": "1.0.0",
-                        "array-uniq": "1.0.3",
-                        "beeper": "1.1.1",
-                        "chalk": "1.1.3",
-                        "dateformat": "1.0.12",
-                        "fancy-log": "1.3.0",
-                        "gulplog": "1.0.0",
-                        "has-gulplog": "0.1.0",
-                        "lodash._reescape": "3.0.0",
-                        "lodash._reevaluate": "3.0.0",
-                        "lodash._reinterpolate": "3.0.0",
-                        "lodash.template": "3.6.2",
-                        "minimist": "1.2.0",
-                        "multipipe": "0.1.2",
-                        "object-assign": "3.0.0",
+                        "array-differ": "^1.0.0",
+                        "array-uniq": "^1.0.2",
+                        "beeper": "^1.0.0",
+                        "chalk": "^1.0.0",
+                        "dateformat": "^1.0.11",
+                        "fancy-log": "^1.1.0",
+                        "gulplog": "^1.0.0",
+                        "has-gulplog": "^0.1.0",
+                        "lodash._reescape": "^3.0.0",
+                        "lodash._reevaluate": "^3.0.0",
+                        "lodash._reinterpolate": "^3.0.0",
+                        "lodash.template": "^3.0.0",
+                        "minimist": "^1.1.0",
+                        "multipipe": "^0.1.2",
+                        "object-assign": "^3.0.0",
                         "replace-ext": "0.0.1",
-                        "through2": "2.0.1",
-                        "vinyl": "0.5.3"
+                        "through2": "^2.0.0",
+                        "vinyl": "^0.5.0"
                     }
                 },
                 "has-flag": {
@@ -4551,20 +4552,20 @@
                     "integrity": "sha1-W3FO4K5JOsXvIEuZ84crzu9z1To=",
                     "dev": true,
                     "requires": {
-                        "abbrev": "1.0.9",
-                        "async": "1.5.2",
-                        "escodegen": "1.8.1",
-                        "esprima": "2.7.3",
-                        "fileset": "0.2.1",
-                        "handlebars": "4.0.11",
-                        "js-yaml": "3.12.0",
-                        "mkdirp": "0.5.1",
-                        "nopt": "3.0.6",
-                        "once": "1.4.0",
-                        "resolve": "1.1.7",
-                        "supports-color": "3.2.3",
-                        "which": "1.3.0",
-                        "wordwrap": "1.0.0"
+                        "abbrev": "1.0.x",
+                        "async": "1.x",
+                        "escodegen": "1.8.x",
+                        "esprima": "2.7.x",
+                        "fileset": "0.2.x",
+                        "handlebars": "^4.0.1",
+                        "js-yaml": "3.x",
+                        "mkdirp": "0.5.x",
+                        "nopt": "3.x",
+                        "once": "1.x",
+                        "resolve": "1.1.x",
+                        "supports-color": "^3.1.0",
+                        "which": "^1.1.1",
+                        "wordwrap": "^1.0.0"
                     }
                 },
                 "readable-stream": {
@@ -4573,12 +4574,12 @@
                     "integrity": "sha1-j5A0HmilPMySh4jaz80Rs265t44=",
                     "dev": true,
                     "requires": {
-                        "core-util-is": "1.0.2",
-                        "inherits": "2.0.3",
-                        "isarray": "1.0.0",
-                        "process-nextick-args": "1.0.7",
-                        "string_decoder": "0.10.31",
-                        "util-deprecate": "1.0.2"
+                        "core-util-is": "~1.0.0",
+                        "inherits": "~2.0.1",
+                        "isarray": "~1.0.0",
+                        "process-nextick-args": "~1.0.6",
+                        "string_decoder": "~0.10.x",
+                        "util-deprecate": "~1.0.1"
                     }
                 },
                 "string_decoder": {
@@ -4593,7 +4594,7 @@
                     "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
                     "dev": true,
                     "requires": {
-                        "has-flag": "1.0.0"
+                        "has-flag": "^1.0.0"
                     }
                 },
                 "through2": {
@@ -4602,8 +4603,8 @@
                     "integrity": "sha1-OE51MU1J8y3hLuu4E2uOtrXVnak=",
                     "dev": true,
                     "requires": {
-                        "readable-stream": "2.0.6",
-                        "xtend": "4.0.1"
+                        "readable-stream": "~2.0.0",
+                        "xtend": "~4.0.0"
                     }
                 }
             }
@@ -4632,7 +4633,7 @@
             "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
             "dev": true,
             "requires": {
-                "is-finite": "1.0.2"
+                "is-finite": "^1.0.0"
             }
         },
         "replace-ext": {
@@ -4646,26 +4647,26 @@
             "resolved": "https://registry.npmjs.org/request/-/request-2.87.0.tgz",
             "integrity": "sha512-fcogkm7Az5bsS6Sl0sibkbhcKsnyon/jV1kF3ajGmF0c8HrttdKTPRT9hieOaQHA5HEq6r8OyWOo/o781C1tNw==",
             "requires": {
-                "aws-sign2": "0.7.0",
-                "aws4": "1.6.0",
-                "caseless": "0.12.0",
-                "combined-stream": "1.0.5",
-                "extend": "3.0.1",
-                "forever-agent": "0.6.1",
-                "form-data": "2.3.2",
-                "har-validator": "5.0.3",
-                "http-signature": "1.2.0",
-                "is-typedarray": "1.0.0",
-                "isstream": "0.1.2",
-                "json-stringify-safe": "5.0.1",
-                "mime-types": "2.1.17",
-                "oauth-sign": "0.8.2",
-                "performance-now": "2.1.0",
-                "qs": "6.5.2",
-                "safe-buffer": "5.1.1",
-                "tough-cookie": "2.3.3",
-                "tunnel-agent": "0.6.0",
-                "uuid": "3.1.0"
+                "aws-sign2": "~0.7.0",
+                "aws4": "^1.6.0",
+                "caseless": "~0.12.0",
+                "combined-stream": "~1.0.5",
+                "extend": "~3.0.1",
+                "forever-agent": "~0.6.1",
+                "form-data": "~2.3.1",
+                "har-validator": "~5.0.3",
+                "http-signature": "~1.2.0",
+                "is-typedarray": "~1.0.0",
+                "isstream": "~0.1.2",
+                "json-stringify-safe": "~5.0.1",
+                "mime-types": "~2.1.17",
+                "oauth-sign": "~0.8.2",
+                "performance-now": "^2.1.0",
+                "qs": "~6.5.1",
+                "safe-buffer": "^5.1.1",
+                "tough-cookie": "~2.3.3",
+                "tunnel-agent": "^0.6.0",
+                "uuid": "^3.1.0"
             },
             "dependencies": {
                 "assert-plus": {
@@ -4688,9 +4689,9 @@
                     "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.2.tgz",
                     "integrity": "sha1-SXBJi+YEwgwAXU9cI67NIda0kJk=",
                     "requires": {
-                        "asynckit": "0.4.0",
+                        "asynckit": "^0.4.0",
                         "combined-stream": "1.0.6",
-                        "mime-types": "2.1.17"
+                        "mime-types": "^2.1.12"
                     },
                     "dependencies": {
                         "combined-stream": {
@@ -4698,7 +4699,7 @@
                             "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.6.tgz",
                             "integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
                             "requires": {
-                                "delayed-stream": "1.0.0"
+                                "delayed-stream": "~1.0.0"
                             }
                         }
                     }
@@ -4708,8 +4709,8 @@
                     "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.0.3.tgz",
                     "integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
                     "requires": {
-                        "ajv": "5.5.2",
-                        "har-schema": "2.0.0"
+                        "ajv": "^5.1.0",
+                        "har-schema": "^2.0.0"
                     }
                 },
                 "http-signature": {
@@ -4717,9 +4718,9 @@
                     "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
                     "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
                     "requires": {
-                        "assert-plus": "1.0.0",
-                        "jsprim": "1.4.1",
-                        "sshpk": "1.13.1"
+                        "assert-plus": "^1.0.0",
+                        "jsprim": "^1.2.2",
+                        "sshpk": "^1.7.0"
                     }
                 },
                 "qs": {
@@ -4732,27 +4733,34 @@
                     "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
                     "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
                     "requires": {
-                        "safe-buffer": "5.1.1"
+                        "safe-buffer": "^5.0.1"
                     }
                 }
             }
         },
         "request-promise-core": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.1.tgz",
-            "integrity": "sha1-Pu4AssWqgyOc+wTFcA2jb4HNCLY=",
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.2.tgz",
+            "integrity": "sha512-UHYyq1MO8GsefGEt7EprS8UrXsm1TxEvFUX1IMTuSLU2Rh7fTIdFtl8xD7JiEYiWU2dl+NYAjCTksTehQUxPag==",
             "requires": {
-                "lodash": "4.17.4"
+                "lodash": "^4.17.11"
+            },
+            "dependencies": {
+                "lodash": {
+                    "version": "4.17.11",
+                    "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
+                    "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
+                }
             }
         },
         "request-promise-native": {
-            "version": "1.0.5",
-            "resolved": "https://registry.npmjs.org/request-promise-native/-/request-promise-native-1.0.5.tgz",
-            "integrity": "sha1-UoF3D2jgyXGeUWP9P6tIIhX0/aU=",
+            "version": "1.0.7",
+            "resolved": "https://registry.npmjs.org/request-promise-native/-/request-promise-native-1.0.7.tgz",
+            "integrity": "sha512-rIMnbBdgNViL37nZ1b3L/VfPOpSi0TqVDQPAvO6U14lMzOLrt5nilxCQqtDKhZeDiW0/hkCXGoQjhgJd/tCh6w==",
             "requires": {
-                "request-promise-core": "1.1.1",
-                "stealthy-require": "1.1.1",
-                "tough-cookie": "2.3.3"
+                "request-promise-core": "1.1.2",
+                "stealthy-require": "^1.1.1",
+                "tough-cookie": "^2.3.3"
             }
         },
         "requires-port": {
@@ -4773,8 +4781,8 @@
             "integrity": "sha1-eaQGRMNivoLybv/nOcm7U4IEb0M=",
             "dev": true,
             "requires": {
-                "expand-tilde": "2.0.2",
-                "global-modules": "1.0.0"
+                "expand-tilde": "^2.0.0",
+                "global-modules": "^1.0.0"
             }
         },
         "resolve-url": {
@@ -4796,7 +4804,7 @@
             "dev": true,
             "optional": true,
             "requires": {
-                "align-text": "0.1.4"
+                "align-text": "^0.1.1"
             }
         },
         "rimraf": {
@@ -4805,7 +4813,7 @@
             "integrity": "sha1-LtgVDSShbqhlHm1u8PR8QVjOejY=",
             "dev": true,
             "requires": {
-                "glob": "7.1.2"
+                "glob": "^7.0.5"
             }
         },
         "run-sequence": {
@@ -4814,9 +4822,9 @@
             "integrity": "sha512-qkzZnQWMZjcKbh3CNly2srtrkaO/2H/SI5f2eliMCapdRD3UhMrwjfOAZJAnZ2H8Ju4aBzFZkBGXUqFs9V0yxw==",
             "dev": true,
             "requires": {
-                "chalk": "1.1.3",
-                "fancy-log": "1.3.2",
-                "plugin-error": "0.1.2"
+                "chalk": "^1.1.3",
+                "fancy-log": "^1.3.2",
+                "plugin-error": "^0.1.2"
             },
             "dependencies": {
                 "arr-diff": {
@@ -4825,8 +4833,8 @@
                     "integrity": "sha1-aHwydYFjWI/vfeezb6vklesaOZo=",
                     "dev": true,
                     "requires": {
-                        "arr-flatten": "1.1.0",
-                        "array-slice": "0.2.3"
+                        "arr-flatten": "^1.0.1",
+                        "array-slice": "^0.2.3"
                     }
                 },
                 "arr-union": {
@@ -4847,7 +4855,7 @@
                     "integrity": "sha1-Gda/lN/AnXa6cR85uHLSH/TdkHE=",
                     "dev": true,
                     "requires": {
-                        "kind-of": "1.1.0"
+                        "kind-of": "^1.1.0"
                     }
                 },
                 "fancy-log": {
@@ -4856,9 +4864,9 @@
                     "integrity": "sha1-9BEl49hPLn2JpD0G2VjI94vha+E=",
                     "dev": true,
                     "requires": {
-                        "ansi-gray": "0.1.1",
-                        "color-support": "1.1.3",
-                        "time-stamp": "1.1.0"
+                        "ansi-gray": "^0.1.1",
+                        "color-support": "^1.1.3",
+                        "time-stamp": "^1.0.0"
                     }
                 },
                 "kind-of": {
@@ -4873,11 +4881,11 @@
                     "integrity": "sha1-O5uzM1zPAPQl4HQ34ZJ2ln2kes4=",
                     "dev": true,
                     "requires": {
-                        "ansi-cyan": "0.1.1",
-                        "ansi-red": "0.1.1",
-                        "arr-diff": "1.1.0",
-                        "arr-union": "2.1.0",
-                        "extend-shallow": "1.1.4"
+                        "ansi-cyan": "^0.1.1",
+                        "ansi-red": "^0.1.1",
+                        "arr-diff": "^1.0.1",
+                        "arr-union": "^2.0.1",
+                        "extend-shallow": "^1.1.2"
                     }
                 }
             }
@@ -4893,7 +4901,7 @@
             "integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
             "dev": true,
             "requires": {
-                "ret": "0.1.15"
+                "ret": "~0.1.10"
             }
         },
         "semver": {
@@ -4914,7 +4922,7 @@
             "integrity": "sha1-12nBgsnVpR9AkUXy+6guXoboA3Y=",
             "dev": true,
             "requires": {
-                "to-object-path": "0.3.0"
+                "to-object-path": "^0.3.0"
             }
         },
         "set-value": {
@@ -4923,10 +4931,10 @@
             "integrity": "sha512-hw0yxk9GT/Hr5yJEYnHNKYXkIA8mVJgd9ditYZCe16ZczcaELYYcfvaXesNACk2O8O0nTiPQcQhGUQj8JLzeeg==",
             "dev": true,
             "requires": {
-                "extend-shallow": "2.0.1",
-                "is-extendable": "0.1.1",
-                "is-plain-object": "2.0.4",
-                "split-string": "3.1.0"
+                "extend-shallow": "^2.0.1",
+                "is-extendable": "^0.1.1",
+                "is-plain-object": "^2.0.3",
+                "split-string": "^3.0.1"
             }
         },
         "should": {
@@ -4935,11 +4943,11 @@
             "integrity": "sha512-ggLesLtu2xp+ZxI+ysJTmNjh2U0TsC+rQ/pfED9bUZZ4DKefP27D+7YJVVTvKsmjLpIi9jAa7itwDGkDDmt1GQ==",
             "dev": true,
             "requires": {
-                "should-equal": "2.0.0",
-                "should-format": "3.0.3",
-                "should-type": "1.4.0",
-                "should-type-adaptors": "1.1.0",
-                "should-util": "1.0.0"
+                "should-equal": "^2.0.0",
+                "should-format": "^3.0.3",
+                "should-type": "^1.4.0",
+                "should-type-adaptors": "^1.0.1",
+                "should-util": "^1.0.0"
             }
         },
         "should-equal": {
@@ -4948,7 +4956,7 @@
             "integrity": "sha512-ZP36TMrK9euEuWQYBig9W55WPC7uo37qzAEmbjHz4gfyuXrEUgF8cUvQVO+w+d3OMfPvSRQJ22lSm8MQJ43LTA==",
             "dev": true,
             "requires": {
-                "should-type": "1.4.0"
+                "should-type": "^1.4.0"
             }
         },
         "should-format": {
@@ -4957,8 +4965,8 @@
             "integrity": "sha1-m/yPdPo5IFxT04w01xcwPidxJPE=",
             "dev": true,
             "requires": {
-                "should-type": "1.4.0",
-                "should-type-adaptors": "1.1.0"
+                "should-type": "^1.3.0",
+                "should-type-adaptors": "^1.0.1"
             }
         },
         "should-type": {
@@ -4973,8 +4981,8 @@
             "integrity": "sha512-JA4hdoLnN+kebEp2Vs8eBe9g7uy0zbRo+RMcU0EsNy+R+k049Ki+N5tT5Jagst2g7EAja+euFuoXFCa8vIklfA==",
             "dev": true,
             "requires": {
-                "should-type": "1.4.0",
-                "should-util": "1.0.0"
+                "should-type": "^1.3.0",
+                "should-util": "^1.0.0"
             }
         },
         "should-util": {
@@ -5001,14 +5009,14 @@
             "integrity": "sha1-4StUh/re0+PeoKyR6UAL91tAE3A=",
             "dev": true,
             "requires": {
-                "base": "0.11.2",
-                "debug": "2.6.9",
-                "define-property": "0.2.5",
-                "extend-shallow": "2.0.1",
-                "map-cache": "0.2.2",
-                "source-map": "0.5.7",
-                "source-map-resolve": "0.5.1",
-                "use": "2.0.2"
+                "base": "^0.11.1",
+                "debug": "^2.2.0",
+                "define-property": "^0.2.5",
+                "extend-shallow": "^2.0.1",
+                "map-cache": "^0.2.2",
+                "source-map": "^0.5.6",
+                "source-map-resolve": "^0.5.0",
+                "use": "^2.0.0"
             },
             "dependencies": {
                 "debug": {
@@ -5035,7 +5043,7 @@
                     "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
                     "dev": true,
                     "requires": {
-                        "kind-of": "3.2.2"
+                        "kind-of": "^3.0.2"
                     },
                     "dependencies": {
                         "kind-of": {
@@ -5044,7 +5052,7 @@
                             "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                             "dev": true,
                             "requires": {
-                                "is-buffer": "1.1.6"
+                                "is-buffer": "^1.1.5"
                             }
                         }
                     }
@@ -5055,7 +5063,7 @@
                     "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
                     "dev": true,
                     "requires": {
-                        "kind-of": "3.2.2"
+                        "kind-of": "^3.0.2"
                     },
                     "dependencies": {
                         "kind-of": {
@@ -5064,7 +5072,7 @@
                             "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                             "dev": true,
                             "requires": {
-                                "is-buffer": "1.1.6"
+                                "is-buffer": "^1.1.5"
                             }
                         }
                     }
@@ -5075,9 +5083,9 @@
                     "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
                     "dev": true,
                     "requires": {
-                        "is-accessor-descriptor": "0.1.6",
-                        "is-data-descriptor": "0.1.4",
-                        "kind-of": "5.1.0"
+                        "is-accessor-descriptor": "^0.1.6",
+                        "is-data-descriptor": "^0.1.4",
+                        "kind-of": "^5.0.0"
                     }
                 },
                 "kind-of": {
@@ -5100,9 +5108,9 @@
             "integrity": "sha512-O27l4xaMYt/RSQ5TR3vpWCAB5Kb/czIcqUFOM/C4fYcLnbZUc1PkjTAMjof2pBWaSTwOUd6qUHcFGVGj7aIwnw==",
             "dev": true,
             "requires": {
-                "define-property": "1.0.0",
-                "isobject": "3.0.1",
-                "snapdragon-util": "3.0.1"
+                "define-property": "^1.0.0",
+                "isobject": "^3.0.0",
+                "snapdragon-util": "^3.0.1"
             },
             "dependencies": {
                 "define-property": {
@@ -5111,7 +5119,7 @@
                     "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
                     "dev": true,
                     "requires": {
-                        "is-descriptor": "1.0.2"
+                        "is-descriptor": "^1.0.0"
                     }
                 },
                 "isobject": {
@@ -5128,7 +5136,7 @@
             "integrity": "sha512-mbKkMdQKsjX4BAL4bRYTj21edOf8cN7XHdYUJEe+Zn99hVEYcMvKPct1IqNe7+AZPirn8BCDOQBHQZknqmKlZQ==",
             "dev": true,
             "requires": {
-                "kind-of": "3.2.2"
+                "kind-of": "^3.2.0"
             }
         },
         "sntp": {
@@ -5137,7 +5145,7 @@
             "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
             "dev": true,
             "requires": {
-                "hoek": "2.16.3"
+                "hoek": "2.x.x"
             }
         },
         "source-map": {
@@ -5152,11 +5160,11 @@
             "integrity": "sha512-0KW2wvzfxm8NCTb30z0LMNyPqWCdDGE2viwzUaucqJdkTRXtZiSY3I+2A6nVAjmdOy0I4gU8DwnVVGsk9jvP2A==",
             "dev": true,
             "requires": {
-                "atob": "2.0.3",
-                "decode-uri-component": "0.2.0",
-                "resolve-url": "0.2.1",
-                "source-map-url": "0.4.0",
-                "urix": "0.1.0"
+                "atob": "^2.0.0",
+                "decode-uri-component": "^0.2.0",
+                "resolve-url": "^0.2.1",
+                "source-map-url": "^0.4.0",
+                "urix": "^0.1.0"
             }
         },
         "source-map-support": {
@@ -5165,8 +5173,8 @@
             "integrity": "sha512-N4KXEz7jcKqPf2b2vZF11lQIz9W5ZMuUcIOGj243lduidkf2fjkVKJS9vNxVWn3u/uxX38AcE8U9nnH9FPcq+g==",
             "dev": true,
             "requires": {
-                "buffer-from": "1.1.1",
-                "source-map": "0.6.1"
+                "buffer-from": "^1.0.0",
+                "source-map": "^0.6.0"
             }
         },
         "source-map-url": {
@@ -5187,7 +5195,7 @@
             "integrity": "sha1-SzBz2TP/UfORLwOsVRlJikFQ20A=",
             "dev": true,
             "requires": {
-                "spdx-license-ids": "1.2.2"
+                "spdx-license-ids": "^1.0.2"
             }
         },
         "spdx-expression-parse": {
@@ -5208,7 +5216,7 @@
             "integrity": "sha1-zQ7qXmOiEd//frDwkcQTPi0N0o8=",
             "dev": true,
             "requires": {
-                "through": "2.3.8"
+                "through": "2"
             }
         },
         "split-string": {
@@ -5217,7 +5225,7 @@
             "integrity": "sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==",
             "dev": true,
             "requires": {
-                "extend-shallow": "3.0.2"
+                "extend-shallow": "^3.0.0"
             },
             "dependencies": {
                 "extend-shallow": {
@@ -5226,8 +5234,8 @@
                     "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
                     "dev": true,
                     "requires": {
-                        "assign-symbols": "1.0.0",
-                        "is-extendable": "1.0.1"
+                        "assign-symbols": "^1.0.0",
+                        "is-extendable": "^1.0.1"
                     }
                 },
                 "is-extendable": {
@@ -5236,7 +5244,7 @@
                     "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
                     "dev": true,
                     "requires": {
-                        "is-plain-object": "2.0.4"
+                        "is-plain-object": "^2.0.4"
                     }
                 }
             }
@@ -5251,14 +5259,14 @@
             "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.1.tgz",
             "integrity": "sha1-US322mKHFEMW3EwY/hzx2UBzm+M=",
             "requires": {
-                "asn1": "0.2.3",
-                "assert-plus": "1.0.0",
-                "bcrypt-pbkdf": "1.0.1",
-                "dashdash": "1.14.1",
-                "ecc-jsbn": "0.1.1",
-                "getpass": "0.1.7",
-                "jsbn": "0.1.1",
-                "tweetnacl": "0.14.5"
+                "asn1": "~0.2.3",
+                "assert-plus": "^1.0.0",
+                "bcrypt-pbkdf": "^1.0.0",
+                "dashdash": "^1.12.0",
+                "ecc-jsbn": "~0.1.1",
+                "getpass": "^0.1.1",
+                "jsbn": "~0.1.0",
+                "tweetnacl": "~0.14.0"
             },
             "dependencies": {
                 "assert-plus": {
@@ -5280,8 +5288,8 @@
             "integrity": "sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=",
             "dev": true,
             "requires": {
-                "define-property": "0.2.5",
-                "object-copy": "0.1.0"
+                "define-property": "^0.2.5",
+                "object-copy": "^0.1.0"
             },
             "dependencies": {
                 "define-property": {
@@ -5290,7 +5298,7 @@
                     "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
                     "dev": true,
                     "requires": {
-                        "is-descriptor": "0.1.6"
+                        "is-descriptor": "^0.1.0"
                     }
                 },
                 "is-accessor-descriptor": {
@@ -5299,7 +5307,7 @@
                     "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
                     "dev": true,
                     "requires": {
-                        "kind-of": "3.2.2"
+                        "kind-of": "^3.0.2"
                     },
                     "dependencies": {
                         "kind-of": {
@@ -5308,7 +5316,7 @@
                             "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                             "dev": true,
                             "requires": {
-                                "is-buffer": "1.1.6"
+                                "is-buffer": "^1.1.5"
                             }
                         }
                     }
@@ -5319,7 +5327,7 @@
                     "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
                     "dev": true,
                     "requires": {
-                        "kind-of": "3.2.2"
+                        "kind-of": "^3.0.2"
                     },
                     "dependencies": {
                         "kind-of": {
@@ -5328,7 +5336,7 @@
                             "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                             "dev": true,
                             "requires": {
-                                "is-buffer": "1.1.6"
+                                "is-buffer": "^1.1.5"
                             }
                         }
                     }
@@ -5339,9 +5347,9 @@
                     "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
                     "dev": true,
                     "requires": {
-                        "is-accessor-descriptor": "0.1.6",
-                        "is-data-descriptor": "0.1.4",
-                        "kind-of": "5.1.0"
+                        "is-accessor-descriptor": "^0.1.6",
+                        "is-data-descriptor": "^0.1.4",
+                        "kind-of": "^5.0.0"
                     }
                 },
                 "kind-of": {
@@ -5363,7 +5371,7 @@
             "integrity": "sha1-TV5DPBhSYd3mI8o/RMWGvPXErRQ=",
             "dev": true,
             "requires": {
-                "duplexer": "0.1.1"
+                "duplexer": "~0.1.1"
             }
         },
         "stream-consume": {
@@ -5384,7 +5392,7 @@
             "integrity": "sha512-Gk6KZM+yNA1JpW0KzlZIhjo3EaBJDkYfXtYSbOwNIQ7Zd6006E6+sCFlW1NDvFG/vnXhKmw6TJJgiEQg/8lXfQ==",
             "dev": true,
             "requires": {
-                "readable-stream": "2.3.3"
+                "readable-stream": "^2.0.2"
             }
         },
         "streamifier": {
@@ -5399,7 +5407,7 @@
             "integrity": "sha1-D8Z9fBQYJd6UKC3VNr7GubzoYKs=",
             "dev": true,
             "requires": {
-                "safe-buffer": "5.1.1"
+                "safe-buffer": "~5.1.0"
             }
         },
         "stringstream": {
@@ -5414,7 +5422,7 @@
             "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
             "dev": true,
             "requires": {
-                "ansi-regex": "2.1.1"
+                "ansi-regex": "^2.0.0"
             }
         },
         "strip-bom": {
@@ -5423,7 +5431,7 @@
             "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
             "dev": true,
             "requires": {
-                "is-utf8": "0.2.1"
+                "is-utf8": "^0.2.0"
             }
         },
         "strip-bom-stream": {
@@ -5432,8 +5440,8 @@
             "integrity": "sha1-5xRDmFd9Uaa+0PoZlPoF9D/ZiO4=",
             "dev": true,
             "requires": {
-                "first-chunk-stream": "1.0.0",
-                "strip-bom": "2.0.0"
+                "first-chunk-stream": "^1.0.0",
+                "strip-bom": "^2.0.0"
             }
         },
         "strip-indent": {
@@ -5442,7 +5450,7 @@
             "integrity": "sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=",
             "dev": true,
             "requires": {
-                "get-stdin": "4.0.1"
+                "get-stdin": "^4.0.1"
             }
         },
         "supports-color": {
@@ -5457,9 +5465,9 @@
             "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
             "dev": true,
             "requires": {
-                "block-stream": "0.0.9",
-                "fstream": "1.0.11",
-                "inherits": "2.0.3"
+                "block-stream": "*",
+                "fstream": "^1.0.2",
+                "inherits": "2"
             }
         },
         "through": {
@@ -5474,8 +5482,8 @@
             "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
             "dev": true,
             "requires": {
-                "readable-stream": "2.3.3",
-                "xtend": "4.0.1"
+                "readable-stream": "^2.1.5",
+                "xtend": "~4.0.1"
             }
         },
         "through2-filter": {
@@ -5484,8 +5492,8 @@
             "integrity": "sha1-YLxVoNrLdghdsfna6Zq0P4PWIuw=",
             "dev": true,
             "requires": {
-                "through2": "2.0.3",
-                "xtend": "4.0.1"
+                "through2": "~2.0.0",
+                "xtend": "~4.0.0"
             }
         },
         "tildify": {
@@ -5494,7 +5502,7 @@
             "integrity": "sha1-3OwD9V3Km3qj5bBPIYF+tW5jWIo=",
             "dev": true,
             "requires": {
-                "os-homedir": "1.0.2"
+                "os-homedir": "^1.0.0"
             }
         },
         "time-stamp": {
@@ -5509,7 +5517,7 @@
             "integrity": "sha1-HN+kcqnvUMI57maZm2YsoOs5k38=",
             "dev": true,
             "requires": {
-                "extend-shallow": "2.0.1"
+                "extend-shallow": "^2.0.1"
             }
         },
         "to-object-path": {
@@ -5518,7 +5526,7 @@
             "integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
             "dev": true,
             "requires": {
-                "kind-of": "3.2.2"
+                "kind-of": "^3.0.2"
             }
         },
         "to-regex": {
@@ -5527,10 +5535,10 @@
             "integrity": "sha512-FWtleNAtZ/Ki2qtqej2CXTOayOH9bHDQF+Q48VpWyDXjbYxA4Yz8iDB31zXOBUlOHHKidDbqGVrTUvQMPmBGBw==",
             "dev": true,
             "requires": {
-                "define-property": "2.0.2",
-                "extend-shallow": "3.0.2",
-                "regex-not": "1.0.2",
-                "safe-regex": "1.1.0"
+                "define-property": "^2.0.2",
+                "extend-shallow": "^3.0.2",
+                "regex-not": "^1.0.2",
+                "safe-regex": "^1.1.0"
             },
             "dependencies": {
                 "extend-shallow": {
@@ -5539,8 +5547,8 @@
                     "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
                     "dev": true,
                     "requires": {
-                        "assign-symbols": "1.0.0",
-                        "is-extendable": "1.0.1"
+                        "assign-symbols": "^1.0.0",
+                        "is-extendable": "^1.0.1"
                     }
                 },
                 "is-extendable": {
@@ -5549,7 +5557,7 @@
                     "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
                     "dev": true,
                     "requires": {
-                        "is-plain-object": "2.0.4"
+                        "is-plain-object": "^2.0.4"
                     }
                 }
             }
@@ -5560,8 +5568,8 @@
             "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
             "dev": true,
             "requires": {
-                "is-number": "3.0.0",
-                "repeat-string": "1.6.1"
+                "is-number": "^3.0.0",
+                "repeat-string": "^1.6.1"
             },
             "dependencies": {
                 "is-number": {
@@ -5570,7 +5578,7 @@
                     "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
                     "dev": true,
                     "requires": {
-                        "kind-of": "3.2.2"
+                        "kind-of": "^3.0.2"
                     }
                 }
             }
@@ -5580,7 +5588,7 @@
             "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.3.tgz",
             "integrity": "sha1-C2GKVWW23qkL80JdBNVe3EdadWE=",
             "requires": {
-                "punycode": "1.4.1"
+                "punycode": "^1.4.1"
             }
         },
         "trim-newlines": {
@@ -5607,7 +5615,7 @@
             "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
             "dev": true,
             "requires": {
-                "prelude-ls": "1.1.2"
+                "prelude-ls": "~1.1.2"
             }
         },
         "typemoq": {
@@ -5616,9 +5624,9 @@
             "integrity": "sha512-DtRNLb7x8yCTv/KHlwes+NI+aGb4Vl1iPC63Hhtcvk1DpxSAZzKWQv0RQFY0jX2Uqj0SDBNl8Na4e6MV6TNDgw==",
             "dev": true,
             "requires": {
-                "circular-json": "0.3.3",
-                "lodash": "4.17.4",
-                "postinstall-build": "5.0.1"
+                "circular-json": "^0.3.1",
+                "lodash": "^4.17.4",
+                "postinstall-build": "^5.0.1"
             }
         },
         "typescript": {
@@ -5634,9 +5642,9 @@
             "dev": true,
             "optional": true,
             "requires": {
-                "source-map": "0.5.7",
-                "uglify-to-browserify": "1.0.2",
-                "yargs": "3.10.0"
+                "source-map": "~0.5.1",
+                "uglify-to-browserify": "~1.0.0",
+                "yargs": "~3.10.0"
             },
             "dependencies": {
                 "source-map": {
@@ -5667,10 +5675,10 @@
             "integrity": "sha1-XHHDTLW61dzr4+oM0IIHulqhrqQ=",
             "dev": true,
             "requires": {
-                "arr-union": "3.1.0",
-                "get-value": "2.0.6",
-                "is-extendable": "0.1.1",
-                "set-value": "0.4.3"
+                "arr-union": "^3.1.0",
+                "get-value": "^2.0.6",
+                "is-extendable": "^0.1.1",
+                "set-value": "^0.4.3"
             },
             "dependencies": {
                 "set-value": {
@@ -5679,10 +5687,10 @@
                     "integrity": "sha1-fbCPnT0i3H945Trzw79GZuzfzPE=",
                     "dev": true,
                     "requires": {
-                        "extend-shallow": "2.0.1",
-                        "is-extendable": "0.1.1",
-                        "is-plain-object": "2.0.4",
-                        "to-object-path": "0.3.0"
+                        "extend-shallow": "^2.0.1",
+                        "is-extendable": "^0.1.1",
+                        "is-plain-object": "^2.0.1",
+                        "to-object-path": "^0.3.0"
                     }
                 }
             }
@@ -5693,8 +5701,8 @@
             "integrity": "sha1-WqADz76Uxf+GbE59ZouxxNuts2k=",
             "dev": true,
             "requires": {
-                "json-stable-stringify": "1.0.1",
-                "through2-filter": "2.0.0"
+                "json-stable-stringify": "^1.0.0",
+                "through2-filter": "^2.0.0"
             }
         },
         "unset-value": {
@@ -5703,8 +5711,8 @@
             "integrity": "sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=",
             "dev": true,
             "requires": {
-                "has-value": "0.3.1",
-                "isobject": "3.0.1"
+                "has-value": "^0.3.1",
+                "isobject": "^3.0.0"
             },
             "dependencies": {
                 "has-value": {
@@ -5713,9 +5721,9 @@
                     "integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
                     "dev": true,
                     "requires": {
-                        "get-value": "2.0.6",
-                        "has-values": "0.1.4",
-                        "isobject": "2.1.0"
+                        "get-value": "^2.0.3",
+                        "has-values": "^0.1.4",
+                        "isobject": "^2.0.0"
                     },
                     "dependencies": {
                         "isobject": {
@@ -5755,8 +5763,8 @@
             "integrity": "sha512-rh+KuAW36YKo0vClhQzLLveoj8FwPJNu65xLb7Mrt+eZht0IPT0IXgSv8gcMegZ6NvjJUALf6Mf25POlMwD1Fw==",
             "dev": true,
             "requires": {
-                "querystringify": "2.0.0",
-                "requires-port": "1.0.0"
+                "querystringify": "^2.0.0",
+                "requires-port": "^1.0.0"
             }
         },
         "use": {
@@ -5765,9 +5773,9 @@
             "integrity": "sha1-riig1y+TvyJCKhii43mZMRLeyOg=",
             "dev": true,
             "requires": {
-                "define-property": "0.2.5",
-                "isobject": "3.0.1",
-                "lazy-cache": "2.0.2"
+                "define-property": "^0.2.5",
+                "isobject": "^3.0.0",
+                "lazy-cache": "^2.0.2"
             },
             "dependencies": {
                 "define-property": {
@@ -5776,7 +5784,7 @@
                     "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
                     "dev": true,
                     "requires": {
-                        "is-descriptor": "0.1.6"
+                        "is-descriptor": "^0.1.0"
                     }
                 },
                 "is-accessor-descriptor": {
@@ -5785,7 +5793,7 @@
                     "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
                     "dev": true,
                     "requires": {
-                        "kind-of": "3.2.2"
+                        "kind-of": "^3.0.2"
                     },
                     "dependencies": {
                         "kind-of": {
@@ -5794,7 +5802,7 @@
                             "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                             "dev": true,
                             "requires": {
-                                "is-buffer": "1.1.6"
+                                "is-buffer": "^1.1.5"
                             }
                         }
                     }
@@ -5805,7 +5813,7 @@
                     "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
                     "dev": true,
                     "requires": {
-                        "kind-of": "3.2.2"
+                        "kind-of": "^3.0.2"
                     },
                     "dependencies": {
                         "kind-of": {
@@ -5814,7 +5822,7 @@
                             "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                             "dev": true,
                             "requires": {
-                                "is-buffer": "1.1.6"
+                                "is-buffer": "^1.1.5"
                             }
                         }
                     }
@@ -5825,9 +5833,9 @@
                     "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
                     "dev": true,
                     "requires": {
-                        "is-accessor-descriptor": "0.1.6",
-                        "is-data-descriptor": "0.1.4",
-                        "kind-of": "5.1.0"
+                        "is-accessor-descriptor": "^0.1.6",
+                        "is-data-descriptor": "^0.1.4",
+                        "kind-of": "^5.0.0"
                     }
                 },
                 "isobject": {
@@ -5848,7 +5856,7 @@
                     "integrity": "sha1-uRkKT5EzVGlIQIWfio9whNiCImQ=",
                     "dev": true,
                     "requires": {
-                        "set-getter": "0.1.0"
+                        "set-getter": "^0.1.0"
                     }
                 }
             }
@@ -5876,7 +5884,7 @@
             "integrity": "sha1-qrGh+jDUX4jdMhFIh1rALAtV5bQ=",
             "dev": true,
             "requires": {
-                "user-home": "1.1.1"
+                "user-home": "^1.1.1"
             }
         },
         "vali-date": {
@@ -5891,8 +5899,8 @@
             "integrity": "sha1-KAS6vnEq0zeUWaz74kdGqywwP7w=",
             "dev": true,
             "requires": {
-                "spdx-correct": "1.0.2",
-                "spdx-expression-parse": "1.0.4"
+                "spdx-correct": "~1.0.0",
+                "spdx-expression-parse": "~1.0.0"
             }
         },
         "verror": {
@@ -5900,9 +5908,9 @@
             "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
             "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
             "requires": {
-                "assert-plus": "1.0.0",
+                "assert-plus": "^1.0.0",
                 "core-util-is": "1.0.2",
-                "extsprintf": "1.3.0"
+                "extsprintf": "^1.2.0"
             },
             "dependencies": {
                 "assert-plus": {
@@ -5918,8 +5926,8 @@
             "integrity": "sha1-sEVbOPxeDPMNQyUTLkYZcMIJHN4=",
             "dev": true,
             "requires": {
-                "clone": "1.0.3",
-                "clone-stats": "0.0.1",
+                "clone": "^1.0.0",
+                "clone-stats": "^0.0.1",
                 "replace-ext": "0.0.1"
             }
         },
@@ -5929,23 +5937,23 @@
             "integrity": "sha1-vm/zJwy1Xf19MGNkDegfJddTIjk=",
             "dev": true,
             "requires": {
-                "duplexify": "3.6.0",
-                "glob-stream": "5.3.5",
-                "graceful-fs": "4.1.11",
+                "duplexify": "^3.2.0",
+                "glob-stream": "^5.3.2",
+                "graceful-fs": "^4.0.0",
                 "gulp-sourcemaps": "1.6.0",
-                "is-valid-glob": "0.3.0",
-                "lazystream": "1.0.0",
-                "lodash.isequal": "4.5.0",
-                "merge-stream": "1.0.1",
-                "mkdirp": "0.5.1",
-                "object-assign": "4.1.1",
-                "readable-stream": "2.3.3",
-                "strip-bom": "2.0.0",
-                "strip-bom-stream": "1.0.0",
-                "through2": "2.0.3",
-                "through2-filter": "2.0.0",
-                "vali-date": "1.0.0",
-                "vinyl": "1.2.0"
+                "is-valid-glob": "^0.3.0",
+                "lazystream": "^1.0.0",
+                "lodash.isequal": "^4.0.0",
+                "merge-stream": "^1.0.0",
+                "mkdirp": "^0.5.0",
+                "object-assign": "^4.0.0",
+                "readable-stream": "^2.0.4",
+                "strip-bom": "^2.0.0",
+                "strip-bom-stream": "^1.0.0",
+                "through2": "^2.0.0",
+                "through2-filter": "^2.0.0",
+                "vali-date": "^1.0.0",
+                "vinyl": "^1.0.0"
             },
             "dependencies": {
                 "object-assign": {
@@ -5960,8 +5968,8 @@
                     "integrity": "sha1-XIgDbPVl5d8FVYv8kR+GVt8hiIQ=",
                     "dev": true,
                     "requires": {
-                        "clone": "1.0.3",
-                        "clone-stats": "0.0.1",
+                        "clone": "^1.0.0",
+                        "clone-stats": "^0.0.1",
                         "replace-ext": "0.0.1"
                     }
                 }
@@ -5973,8 +5981,8 @@
             "integrity": "sha1-YrU6E1YQqJbpjKlr7jqH8Aio54A=",
             "dev": true,
             "requires": {
-                "through2": "2.0.3",
-                "vinyl": "0.4.6"
+                "through2": "^2.0.3",
+                "vinyl": "^0.4.3"
             },
             "dependencies": {
                 "clone": {
@@ -5989,8 +5997,8 @@
                     "integrity": "sha1-LzVsh6VQolVGHza76ypbqL94SEc=",
                     "dev": true,
                     "requires": {
-                        "clone": "0.2.0",
-                        "clone-stats": "0.0.1"
+                        "clone": "^0.2.0",
+                        "clone-stats": "^0.0.1"
                     }
                 }
             }
@@ -6001,20 +6009,20 @@
             "integrity": "sha512-tJl9eL15ZMm6vzCYYeQ26sSYRuXGMGPsaeIAmG2rOOYRn01jdaDg6I4b9G5Ed6FISdmn6egpKThk4o4om8Ax/A==",
             "dev": true,
             "requires": {
-                "glob": "7.1.2",
-                "gulp-chmod": "2.0.0",
-                "gulp-filter": "5.1.0",
+                "glob": "^7.1.2",
+                "gulp-chmod": "^2.0.0",
+                "gulp-filter": "^5.0.1",
                 "gulp-gunzip": "1.0.0",
-                "gulp-remote-src-vscode": "0.5.0",
-                "gulp-symdest": "1.1.0",
-                "gulp-untar": "0.0.7",
-                "gulp-vinyl-zip": "2.1.0",
-                "mocha": "4.1.0",
-                "request": "2.87.0",
-                "semver": "5.4.1",
-                "source-map-support": "0.5.6",
-                "url-parse": "1.4.3",
-                "vinyl-source-stream": "1.1.2"
+                "gulp-remote-src-vscode": "^0.5.0",
+                "gulp-symdest": "^1.1.0",
+                "gulp-untar": "^0.0.7",
+                "gulp-vinyl-zip": "^2.1.0",
+                "mocha": "^4.0.1",
+                "request": "^2.83.0",
+                "semver": "^5.4.1",
+                "source-map-support": "^0.5.0",
+                "url-parse": "^1.4.3",
+                "vinyl-source-stream": "^1.1.0"
             }
         },
         "which": {
@@ -6023,7 +6031,7 @@
             "integrity": "sha512-xcJpopdamTuY5duC/KnTTNBraPK54YwpenP4lzxU8H91GudWpFv38u0CKjclE1Wi2EH2EDz5LRcHcKbCIzqGyg==",
             "dev": true,
             "requires": {
-                "isexe": "2.0.0"
+                "isexe": "^2.0.0"
             }
         },
         "window-size": {
@@ -6058,9 +6066,9 @@
             "dev": true,
             "optional": true,
             "requires": {
-                "camelcase": "1.2.1",
-                "cliui": "2.1.0",
-                "decamelize": "1.2.0",
+                "camelcase": "^1.0.2",
+                "cliui": "^2.1.0",
+                "decamelize": "^1.0.0",
                 "window-size": "0.1.0"
             }
         },
@@ -6070,8 +6078,8 @@
             "integrity": "sha1-x+sXyT4RLLEIb6bY5R+wZnt5pfk=",
             "dev": true,
             "requires": {
-                "buffer-crc32": "0.2.13",
-                "fd-slicer": "1.1.0"
+                "buffer-crc32": "~0.2.3",
+                "fd-slicer": "~1.1.0"
             }
         },
         "yazl": {
@@ -6080,7 +6088,7 @@
             "integrity": "sha1-7CblzIfVYBud+EMtvdPNLlFzoHE=",
             "dev": true,
             "requires": {
-                "buffer-crc32": "0.2.13"
+                "buffer-crc32": "~0.2.3"
             }
         }
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -5630,9 +5630,9 @@
             }
         },
         "typescript": {
-            "version": "2.9.2",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.9.2.tgz",
-            "integrity": "sha512-Gr4p6nFNaoufRIY4NMdpQRNmgxVIGMs4Fcu/ujdYk3nAZqk7supzBE9idmvfZIlH/Cuj//dvi+019qEue9lV0w==",
+            "version": "3.3.3333",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.3.3333.tgz",
+            "integrity": "sha512-JjSKsAfuHBE/fB2oZ8NxtRTk5iGcg6hkYXMnZ3Wc+b2RSqejEqTaem11mHASMnFilHrax3sLK0GDzcJrekZYLw==",
             "dev": true
         },
         "uglify-js": {

--- a/package.json
+++ b/package.json
@@ -388,7 +388,7 @@
         "run-sequence": "^2.2.1",
         "should": "latest",
         "typemoq": "latest",
-        "typescript": "^2.6.1",
-        "vscode": "^1.1.21"
+        "typescript": "latest",
+        "vscode": "^1.1.30"
     }
 }

--- a/package.json
+++ b/package.json
@@ -45,6 +45,18 @@
         "roby"
     ],
     "contributes": {
+        "configuration": {
+            "type": "object",
+            "title": "Rock Workspace Configuration",
+            "properties": {
+                "rock.devFolder": {
+                    "title": "Dev Folder",
+                    "type": "string",
+                    "default": null,
+                    "description": "Toplevel path in which your workspaces are stored"
+                }
+            }
+        },
         "debuggers": [
             {
                 "type": "orogen",
@@ -113,6 +125,11 @@
                 "title": "Add launch config",
                 "category": "Rock",
                 "command": "rock.addLaunchConfig"
+            },
+            {
+                "title": "Add workspace",
+                "category": "Rock",
+                "command": "rock.addWorkspace"
             },
             {
                 "title": "Add package to workspace",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
         "url": "https://github.com/rock-core/vscode-rock.git"
     },
     "engines": {
-        "vscode": "^1.21.0"
+        "vscode": "^1.30.0"
     },
     "activationEvents": [
         "*"
@@ -287,7 +287,11 @@
         "taskDefinitions": [
             {
                 "type": "autoproj-package",
-                "required": ["workspace", "mode", "path"],
+                "required": [
+                    "workspace",
+                    "mode",
+                    "path"
+                ],
                 "properties": {
                     "workspace": {
                         "type": "string",
@@ -312,7 +316,10 @@
             },
             {
                 "type": "autoproj-workspace",
-                "required": ["workspace", "mode"],
+                "required": [
+                    "workspace",
+                    "mode"
+                ],
                 "properties": {
                     "workspace": {
                         "type": "string",

--- a/package.json
+++ b/package.json
@@ -50,10 +50,9 @@
             "title": "Rock Workspace Configuration",
             "properties": {
                 "rock.devFolder": {
-                    "title": "Dev Folder",
                     "type": "string",
                     "default": null,
-                    "description": "Toplevel path in which your workspaces are stored"
+                    "description": "Toplevel path in which your workspaces are stored, to speed up selection in the Add Workspace command"
                 }
             }
         },

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -214,6 +214,38 @@ export class Commands
         return choices;
     }
 
+    async addWorkspace()
+    {
+        let defaultUri;
+        let dev = this._context.workspaces.devFolder;
+        if (dev) {
+            defaultUri = vscode.Uri.file(dev);
+        }
+
+        let paths = await this._vscode.showOpenDialog(
+            { canSelectFiles: false, canSelectFolders: true, canSelectMany: true,
+              defaultUri: defaultUri, openLabel: 'Select the workspace(s) to add' });
+        if (!paths) {
+            return;
+        }
+
+        paths.forEach((p) => {
+            let root = autoproj.findWorkspaceRoot(p.fsPath);
+            if (root) {
+                let wsname = basename(root);
+                let configUri = vscode.Uri.file(pathjoin(root, 'autoproj'));
+
+                let folder = { name: `autoproj (${wsname})`, uri: configUri };
+                const wsFolders = this._vscode.workspaceFolders;
+                let insertPosition = 0;
+                if (wsFolders) {
+                    insertPosition = wsFolders.length;
+                }
+                this._vscode.updateWorkspaceFolders(insertPosition, null, folder);
+            }
+        })
+    }
+
     async addPackageToWorkspace()
     {
         const tokenSource = new vscode.CancellationTokenSource();
@@ -266,5 +298,6 @@ export class Commands
         this._vscode.registerAndSubscribeCommand('rock.updateCodeConfig', () => { this.updateCodeConfig() });
         this._vscode.registerAndSubscribeCommand('rock.showOutputChannel', () => { this.showOutputChannel() });
         this._vscode.registerAndSubscribeCommand('rock.addPackageToWorkspace', () => { this.addPackageToWorkspace() });
+        this._vscode.registerAndSubscribeCommand('rock.addWorkspace', () => { this.addWorkspace() });
     }
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -44,6 +44,11 @@ export class ConfigManager
 
         return this.writeCppProperties(pkgPath, pkgModel);
     }
+
+    public getDevFolder() : string | null {
+        return this._vscode.getConfiguration().get<string|null>('rock.devFolder', null);
+    }
+
     private writeCppProperties(pkgPath: string, pkgModel: autoproj.Package): boolean
     {
         const dbPath = path.join(pkgModel.builddir, "compile_commands.json");

--- a/src/context.ts
+++ b/src/context.ts
@@ -46,8 +46,7 @@ export class Context
     }
 
     public isWorkspaceEmpty() : boolean {
-        let folders = this._vscode.workspaceFolders;
-        return (!folders || folders.length == 0);
+        return this._vscode.workspaceFolders.length === 0;
     }
 
     public getWorkspaceByPath(path : string) : autoproj.Workspace | undefined

--- a/src/context.ts
+++ b/src/context.ts
@@ -45,6 +45,10 @@ export class Context
         return this._contextUpdatedEvent.event(callback);
     }
 
+    public get vscode() : wrappers.VSCode {
+        return this._vscode;
+    }
+
     public isWorkspaceEmpty() : boolean {
         return this._vscode.workspaceFolders.length === 0;
     }

--- a/src/disposables.ts
+++ b/src/disposables.ts
@@ -1,0 +1,20 @@
+'use strict';
+
+import * as vscode from 'vscode';
+
+export function forProcess(
+    processId: number, signal : string = 'SIGINT') : vscode.Disposable {
+    return new vscode.Disposable(() => {
+        try {
+            process.kill(processId, signal);
+        }
+        catch(err) { }
+    })
+}
+
+export function forTask(
+    execution: vscode.TaskExecution) : vscode.Disposable {
+    return new vscode.Disposable(() => {
+        execution.terminate()
+    })
+}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -106,6 +106,11 @@ function setupEvents(rockContext: context.Context, extensionContext: vscode.Exte
     );
 }
 
+function applyConfiguration(configManager : config.ConfigManager,
+    workspaces : autoproj.Workspaces) : void {
+    workspaces.devFolder = configManager.getDevFolder();
+}
+
 // this method is called when your extension is activated
 // your extension is activated the very first time the command is executed
 export function activate(extensionContext: vscode.ExtensionContext) {
@@ -122,7 +127,12 @@ export function activate(extensionContext: vscode.ExtensionContext) {
     let configManager = new config.ConfigManager(workspaces, vscodeWrapper);
     let rockCommands = new commands.Commands(rockContext, vscodeWrapper, configManager);
 
-    vscode.tasks.onDidEndTask((event) => workspaces.notifyEndTask(event.execution))
+    applyConfiguration(configManager, workspaces);
+    extensionContext.subscriptions.push(
+        vscode.workspace.onDidChangeConfiguration(
+            () => applyConfiguration(configManager, workspaces)))
+    extensionContext.subscriptions.push(
+        vscode.tasks.onDidEndTask((event) => workspaces.notifyEndTask(event.execution)))
 
     extensionContext.subscriptions.push(
         vscode.workspace.registerTaskProvider('autoproj', autoprojTaskProvider));

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -42,7 +42,10 @@ export function activate(extensionContext: vscode.ExtensionContext) {
         vscode.workspace.onDidChangeConfiguration(
             () => applyConfiguration(configManager, workspaces)))
     extensionContext.subscriptions.push(
-        vscode.tasks.onDidEndTask((event) => workspaces.notifyEndTask(event.execution)))
+        vscode.tasks.onDidStartTaskProcess((event) => {
+            workspaces.notifyStartTaskProcess(event)
+        })
+    )
 
     extensionContext.subscriptions.push(
         vscode.workspace.registerTaskProvider('autoproj', autoprojTaskProvider));

--- a/src/tasks.ts
+++ b/src/tasks.ts
@@ -8,6 +8,13 @@ function runAutoproj(ws, ...args) {
     return new vscode.ProcessExecution(ws.autoprojExePath(), args, { cwd: ws.root })
 }
 
+export function workspaceFromTask(task : vscode.Task, workspaces : autoproj.Workspaces) : autoproj.Workspace | undefined {
+    let root = task.definition.workspace;
+    if (root) {
+        return workspaces.getWorkspaceFromRoot(root);
+    }
+}
+
 export class AutoprojProvider implements vscode.TaskProvider
 {
     workspaces : autoproj.Workspaces;

--- a/src/vscode_workspace_manager.ts
+++ b/src/vscode_workspace_manager.ts
@@ -1,0 +1,134 @@
+'use strict';
+// The module 'vscode' contains the VS Code extensibility API
+// Import the module and reference it with the alias vscode in your code below
+import * as vscode from 'vscode';
+import * as tasks from './tasks';
+import * as wrappers from './wrappers';
+import * as context from './context';
+import * as autoproj from './autoproj';
+import * as commands from './commands';
+import * as packages from './packages';
+import * as debug from './debug';
+import * as config from './config';
+import * as fs from 'fs';
+import { join as joinpath } from 'path';
+import * as snippets from './snippets';
+import * as watcher from './watcher';
+import * as path from 'path'
+
+export class Manager {
+    private _rockContext : context.Context;
+    private _workspaces : autoproj.Workspaces;
+    private _taskProvider : tasks.AutoprojProvider;
+    private _configManager : config.ConfigManager;
+    private _fileWatcher : watcher.FileWatcher;
+
+    constructor(rockContext : context.Context, workspaces : autoproj.Workspaces,
+        taskProvider : tasks.AutoprojProvider, configManager : config.ConfigManager,
+        fileWatcher : watcher.FileWatcher) {
+
+        this._rockContext   = rockContext;
+        this._workspaces    = workspaces;
+        this._taskProvider  = taskProvider;
+        this._configManager = configManager;
+        this._fileWatcher   = fileWatcher;
+    }
+
+    watchManifest(ws : autoproj.Workspace) {
+        let manifestPath = autoproj.installationManifestPath(ws.root);
+        try {
+            this._fileWatcher.startWatching(manifestPath, (filePath) => {
+                ws.reload().catch(err => {
+                        let errMsg = `Could not load installation manifest: ${err.message}`
+                        vscode.window.showErrorMessage(errMsg);
+                    }
+                );
+            });
+        }
+        catch (err) {
+            vscode.window.showErrorMessage(err.message);
+        }
+    }
+
+    unwatchManifest(ws : autoproj.Workspace) {
+        let manifestPath = autoproj.installationManifestPath(ws.root);
+        try {
+            this._fileWatcher.stopWatching(manifestPath);
+        }
+        catch (err) {
+            vscode.window.showErrorMessage(err.message);
+        }
+    }
+
+    handleNewFolder(index: number, path: string) : number
+    {
+        let wsRoot = autoproj.findWorkspaceRoot(path);
+        if (!wsRoot) {
+            return index;
+        }
+
+        // Auto-add the workspace's autoproj folder
+        let configIndex = commands.findAutoprojFolderIndex(
+            this._rockContext.vscode.workspaceFolders as vscode.WorkspaceFolder[],
+            { root: wsRoot });
+
+        if (configIndex === undefined) {
+            // Add the config folder just before this folder and return. vscode will
+            // call us back for the config folder. This way, we also workaround the
+            // VSCode < 1.30 behavior of restarting extensions when the first folder
+            // is changed.
+            commands.addAutoprojFolder(this._rockContext.vscode, wsRoot, index);
+            return index + 1;
+        }
+
+        const { added, workspace } = this._workspaces.addFolder(path);
+        if (added && workspace) {
+            this.setupNewWorkspace(workspace);
+        }
+        this._configManager.setupPackage(path).catch((reason) => {
+            vscode.window.showErrorMessage(reason.message);
+        });
+        return index;
+    }
+
+    setupNewWorkspace(workspace : autoproj.Workspace) {
+        workspace.info().catch(err => {
+            let errMsg = `Could not load installation manifest: ${err.message}`
+            vscode.window.showErrorMessage(errMsg);
+        })
+
+        this._taskProvider.reloadTasks();
+        workspace.ensureSyskitContextAvailable().catch(() => {})
+        let watchTask = this._taskProvider.watchTask(workspace.root)
+        vscode.tasks.executeTask(watchTask).
+            then((taskExecution) => workspace.associateTask(taskExecution))
+        this.watchManifest(workspace);
+    }
+
+    initializeWorkspaces(folders : vscode.WorkspaceFolder[]) {
+        let index = 0;
+        folders.forEach((folder) => {
+            index = this.handleNewFolder(index, folder.uri.fsPath);
+        });
+    }
+
+    handleDeletedFolder(path: string) {
+        let deletedWs = this._workspaces.deleteFolder(path);
+        this._taskProvider.reloadTasks();
+        if (deletedWs) {
+            this.unwatchManifest(deletedWs);
+            deletedWs.readWatchPID().
+                then((pid) => process.kill(pid, 'SIGINT')).
+                catch(() => {})
+        }
+    }
+
+    handleWorkspaceChangeEvent(event : vscode.WorkspaceFoldersChangeEvent) {
+        event.added.forEach((folder) => {
+            this.handleNewFolder(folder.index, folder.uri.fsPath);
+        });
+        event.removed.forEach((folder) => {
+            this.handleDeletedFolder(folder.uri.fsPath);
+        });
+    }
+};

--- a/src/vscode_workspace_manager.ts
+++ b/src/vscode_workspace_manager.ts
@@ -2,6 +2,7 @@
 // The module 'vscode' contains the VS Code extensibility API
 // Import the module and reference it with the alias vscode in your code below
 import * as vscode from 'vscode';
+import * as disposables from './disposables';
 import * as tasks from './tasks';
 import * as wrappers from './wrappers';
 import * as context from './context';
@@ -101,7 +102,9 @@ export class Manager {
         workspace.ensureSyskitContextAvailable().catch(() => {})
         let watchTask = this._taskProvider.watchTask(workspace.root)
         vscode.tasks.executeTask(watchTask).
-            then((taskExecution) => workspace.associateTask(taskExecution))
+            then((execution) => {
+                workspace.subscribe(disposables.forTask(execution))
+            })
         this.watchManifest(workspace);
     }
 
@@ -117,9 +120,7 @@ export class Manager {
         this._taskProvider.reloadTasks();
         if (deletedWs) {
             this.unwatchManifest(deletedWs);
-            deletedWs.readWatchPID().
-                then((pid) => process.kill(pid, 'SIGINT')).
-                catch(() => {})
+            deletedWs.dispose()
         }
     }
 

--- a/src/wrappers.ts
+++ b/src/wrappers.ts
@@ -29,9 +29,12 @@ export class VSCode {
         return vscode.window.activeTextEditor;
     }
 
-    public get workspaceFolders(): vscode.WorkspaceFolder[] | undefined
+    public get workspaceFolders(): vscode.WorkspaceFolder[]
     {
-        return vscode.workspace.workspaceFolders;
+        let folders = vscode.workspace.workspaceFolders;
+        if (folders)
+            return folders;
+        else return [];
     }
 
     public getWorkspaceFolder(uri: vscode.Uri | string): vscode.WorkspaceFolder | undefined

--- a/test/commands.test.ts
+++ b/test/commands.test.ts
@@ -403,22 +403,22 @@ describe("Commands", function () {
         beforeEach(function () {
             mockPackageOne = TypeMoq.Mock.ofType<autoproj.Package>();
             mockPackageTwo = TypeMoq.Mock.ofType<autoproj.Package>();
-            mockPackageOne.setup(x => x.srcdir).returns(() => '/path/to/one');
-            mockPackageTwo.setup(x => x.srcdir).returns(() => '/path/to/two');
+            mockPackageOne.setup(x => x.srcdir).returns(() => '/test/one');
+            mockPackageTwo.setup(x => x.srcdir).returns(() => '/test/two');
             mockPackageOne.setup(x => x.name).returns(() => 'one');
             mockPackageTwo.setup(x => x.name).returns(() => 'two');
             choices = [{
                 label: 'one',
                 description: 'to',
-                config: true,
-                ws: {root: "/test"},
+                config: false,
+                ws: {name: 'test', root: "/test"},
                 pkg: mockPackageOne.object
             },
             {
                 label: 'two',
                 description: 'to',
-                config: true,
-                ws: {root: "/test"},
+                config: false,
+                ws: {name: 'test', root: "/test"},
                 pkg: mockPackageTwo.object
             }];
             mockSubject = TypeMoq.Mock.ofInstance(subject);
@@ -452,10 +452,11 @@ describe("Commands", function () {
             await subject.addPackageToWorkspace();
 
             mockWrapper.verify(x => x.updateWorkspaceFolders(0, null,
-                { name: 'two', uri: vscode.Uri.file('/path/to/two') }),
+                { name: 'autoproj (test)', uri: vscode.Uri.file('/test/autoproj') },
+                { name: 'two', uri: vscode.Uri.file('/test/two') }),
                 TypeMoq.Times.once());
         })
-        it("auto-inserts the autopproj configuration", async function () {
+        it("auto-inserts the autoproj configuration", async function () {
             choices[0].config = false;
             choices[0].ws.name = 'test';
             const promise = Promise.resolve(choices);
@@ -467,22 +468,17 @@ describe("Commands", function () {
             await subject.addPackageToWorkspace();
 
             mockWrapper.verify(x => x.updateWorkspaceFolders(0, null,
-                { name: 'autoproj (test)', uri: vscode.Uri.file('/test/autoproj') }),
-                TypeMoq.Times.once());
-            mockWrapper.verify(x => x.updateWorkspaceFolders(1, null,
-                { name: 'one', uri: vscode.Uri.file('/path/to/one') }),
+                { name: 'autoproj (test)', uri: vscode.Uri.file('/test/autoproj') },
+                { name: 'one', uri: vscode.Uri.file('/test/one') }),
                 TypeMoq.Times.once());
         })
         it("does not attempt to auto-insert the configuration if it's already there", async function () {
-            const folder: vscode.WorkspaceFolder = {
-                uri: vscode.Uri.file('/test/autoproj'),
-                name: 'autoproj (test)',
-                index: 0
-            }
+            const existing: vscode.WorkspaceFolder[] = [
+                { uri: vscode.Uri.file('/test/autoproj'), name: '', index: 0 }];
             choices[0].config = false;
             choices[0].ws.name = 'test';
             const promise = Promise.resolve(choices);
-            mockWrapper.setup(x => x.workspaceFolders).returns(() => [folder]);
+            mockWrapper.setup(x => x.workspaceFolders).returns(() => existing);
             mockSubject.setup(x => x.packagePickerChoices()).
                 returns(() => promise);
             mockWrapper.setup(x => x.showQuickPick(promise,
@@ -493,30 +489,44 @@ describe("Commands", function () {
                 { name: 'autoproj (test)', uri: vscode.Uri.file('/test/autoproj') }),
                 TypeMoq.Times.never());
             mockWrapper.verify(x => x.updateWorkspaceFolders(1, null,
-                { name: 'one', uri: vscode.Uri.file('/path/to/one') }),
+                { name: 'one', uri: vscode.Uri.file('/test/one') }),
                 TypeMoq.Times.once());
         })
-        it("inserts alphabetically before the first item", async function () {
-            const folder: vscode.WorkspaceFolder = {
-                uri: vscode.Uri.file('/path/to/two'),
-                name: 'two',
-                index: 0
-            }
+        it("inserts after an existing build configuration", async function () {
+            const existing: vscode.WorkspaceFolder[] = [
+                { uri: vscode.Uri.file('/unrelated'), name: 'unrelated', index: 0 },
+                { uri: vscode.Uri.file('/test/autoproj'), name: '', index: 1 }]
             const promise = Promise.resolve(choices);
-            mockWrapper.setup(x => x.workspaceFolders).returns(() => [folder]);
+            mockWrapper.setup(x => x.workspaceFolders).returns(() => existing);
             mockSubject.setup(x => x.packagePickerChoices()).
                 returns(() => promise);
             mockWrapper.setup(x => x.showQuickPick(promise,
                 options, TypeMoq.It.isAny())).returns(() => Promise.resolve(choices[0]));
             await subject.addPackageToWorkspace();
 
-            mockWrapper.verify(x => x.updateWorkspaceFolders(0, null,
-                { name: 'one', uri: vscode.Uri.file('/path/to/one') }),
+            mockWrapper.verify(x => x.updateWorkspaceFolders(2, null,
+                { name: 'one', uri: vscode.Uri.file('/test/one') }),
+                TypeMoq.Times.once());
+        })
+        it("inserts alphabetically before the first item", async function () {
+            const existing: vscode.WorkspaceFolder[] = [
+                { uri: vscode.Uri.file('/test/autoproj'), name: '', index: 0 },
+                { uri: vscode.Uri.file('/test/two'), name: 'two', index: 1 }];
+            const promise = Promise.resolve(choices);
+            mockWrapper.setup(x => x.workspaceFolders).returns(() => existing);
+            mockSubject.setup(x => x.packagePickerChoices()).
+                returns(() => promise);
+            mockWrapper.setup(x => x.showQuickPick(promise,
+                options, TypeMoq.It.isAny())).returns(() => Promise.resolve(choices[0]));
+            await subject.addPackageToWorkspace();
+
+            mockWrapper.verify(x => x.updateWorkspaceFolders(1, null,
+                { name: 'one', uri: vscode.Uri.file('/test/one') }),
                 TypeMoq.Times.once());
         })
         it("inserts alphabetically in the middle of existing items", async function () {
             let mockPackageThree = TypeMoq.Mock.ofType<autoproj.Package>();
-            mockPackageThree.setup(x => x.srcdir).returns(() => '/path/to/three');
+            mockPackageThree.setup(x => x.srcdir).returns(() => '/test/three');
             mockPackageThree.setup(x => x.name).returns(() => 'three');
             let common = { config: true, ws: { root: '/test' }, description: 'to' };
             choices = [{ label: 'one', pkg: mockPackageOne.object, ...common },
@@ -524,8 +534,9 @@ describe("Commands", function () {
                 { label: 'two', pkg: mockPackageTwo.object, ...common }];
 
             const existing: vscode.WorkspaceFolder[] = [
-                { uri: vscode.Uri.file('/path/to/one'), name: 'one', index: 0 },
-                { uri: vscode.Uri.file('/path/to/two'), name: 'two', index: 0 }]
+                { uri: vscode.Uri.file('/test/autoproj'), name: '', index: 0 },
+                { uri: vscode.Uri.file('/test/one'), name: 'one', index: 1 },
+                { uri: vscode.Uri.file('/test/two'), name: 'two', index: 2 }];
             const promise = Promise.resolve(choices);
             mockWrapper.setup(x => x.workspaceFolders).returns(() => existing);
             mockSubject.setup(x => x.packagePickerChoices()).
@@ -534,26 +545,41 @@ describe("Commands", function () {
                 options, TypeMoq.It.isAny())).returns(() => Promise.resolve(choices[1]));
             await subject.addPackageToWorkspace();
 
-            mockWrapper.verify(x => x.updateWorkspaceFolders(1, null,
-                { name: 'three', uri: vscode.Uri.file('/path/to/three') }),
+            mockWrapper.verify(x => x.updateWorkspaceFolders(2, null,
+                { name: 'three', uri: vscode.Uri.file('/test/three') }),
                 TypeMoq.Times.once());
         })
         it("inserts alphabetically after the last item", async function () {
-            const folder: vscode.WorkspaceFolder = {
-                uri: vscode.Uri.file('/path/to/one'),
-                name: 'one',
-                index: 0
-            }
+            const existing: vscode.WorkspaceFolder[] = [
+                { uri: vscode.Uri.file('/test/autoproj'), name: '', index: 0 },
+                { uri: vscode.Uri.file('/test/one'), name: 'one', index: 1 }];
             const promise = Promise.resolve(choices);
-            mockWrapper.setup(x => x.workspaceFolders).returns(() => [folder]);
+            mockWrapper.setup(x => x.workspaceFolders).returns(() => existing);
             mockSubject.setup(x => x.packagePickerChoices()).
                 returns(() => promise);
             mockWrapper.setup(x => x.showQuickPick(promise,
                 options, TypeMoq.It.isAny())).returns(() => Promise.resolve(choices[1]));
             await subject.addPackageToWorkspace();
 
-            mockWrapper.verify(x => x.updateWorkspaceFolders(1, null,
-                { name: 'two', uri: vscode.Uri.file('/path/to/two') }),
+            mockWrapper.verify(x => x.updateWorkspaceFolders(2, null,
+                { name: 'two', uri: vscode.Uri.file('/test/two') }),
+                TypeMoq.Times.once());
+        })
+        it("stops before follow-up items that are not part of the workspace", async function () {
+            const existing: vscode.WorkspaceFolder[] = [
+                { uri: vscode.Uri.file('/test/autoproj'), name: '', index: 0 },
+                { uri: vscode.Uri.file('/test/one'), name: 'one', index: 1 },
+                { uri: vscode.Uri.file('/unrelated'), name: 'unrelated', index: 2 }];
+            const promise = Promise.resolve(choices);
+            mockWrapper.setup(x => x.workspaceFolders).returns(() => existing);
+            mockSubject.setup(x => x.packagePickerChoices()).
+                returns(() => promise);
+            mockWrapper.setup(x => x.showQuickPick(promise,
+                options, TypeMoq.It.isAny())).returns(() => Promise.resolve(choices[1]));
+            await subject.addPackageToWorkspace();
+
+            mockWrapper.verify(x => x.updateWorkspaceFolders(2, null,
+                { name: 'two', uri: vscode.Uri.file('/test/two') }),
                 TypeMoq.Times.once());
         })
         it("shows an error if folder could not be added", async function () {
@@ -564,10 +590,10 @@ describe("Commands", function () {
             mockWrapper.setup(x => x.showQuickPick(promise,
                 options, TypeMoq.It.isAny())).returns(() => Promise.resolve(choices[1]));
             mockWrapper.setup(x => x.updateWorkspaceFolders(0, null,
-                    { uri: vscode.Uri.file('/path/to/two') })).returns(() => false);
+                    { uri: vscode.Uri.file('/test/two') })).returns(() => false);
 
             await subject.addPackageToWorkspace();
-            mockWrapper.verify(x => x.showErrorMessage("Could not add folder: /path/to/two"),
+            mockWrapper.verify(x => x.showErrorMessage("Could not add folder: /test/two"),
                 TypeMoq.Times.once());
         })
     })

--- a/test/commands.test.ts
+++ b/test/commands.test.ts
@@ -348,13 +348,13 @@ describe("Commands", function () {
                 callback((cb) => cb(mockWs.object));
         })
         it("throws if installation manifest loading fails", async function () {
-            mockWrapper.setup(x => x.workspaceFolders).returns(() => undefined);
+            mockWrapper.setup(x => x.workspaceFolders).returns(() => []);
             mockWs.setup(x => x.info()).returns(() => Promise.reject('test'));
             await helpers.assertThrowsAsync(subject.packagePickerChoices(),
                 /Could not load installation manifest/)
         })
         it("returns all packages if workspace is empty", async function () {
-            mockWrapper.setup(x => x.workspaceFolders).returns(() => undefined);
+            mockWrapper.setup(x => x.workspaceFolders).returns(() => []);
             mockWs.setup(x => x.info()).returns(() => Promise.resolve(mockWsInfo.object));
             mockWsInfo.setup(x => x.packages).returns(() => pathToPackage);
 
@@ -444,7 +444,7 @@ describe("Commands", function () {
         })
         it("handles an empty workspace", async function () {
             const promise = Promise.resolve(choices);
-            mockWrapper.setup(x => x.workspaceFolders).returns(() => undefined);
+            mockWrapper.setup(x => x.workspaceFolders).returns(() => []);
             mockSubject.setup(x => x.packagePickerChoices()).
                 returns(() => promise);
             mockWrapper.setup(x => x.showQuickPick(promise,
@@ -460,7 +460,7 @@ describe("Commands", function () {
             choices[0].config = false;
             choices[0].ws.name = 'test';
             const promise = Promise.resolve(choices);
-            mockWrapper.setup(x => x.workspaceFolders).returns(() => undefined);
+            mockWrapper.setup(x => x.workspaceFolders).returns(() => []);
             mockSubject.setup(x => x.packagePickerChoices()).
                 returns(() => promise);
             mockWrapper.setup(x => x.showQuickPick(promise,
@@ -584,7 +584,7 @@ describe("Commands", function () {
         })
         it("shows an error if folder could not be added", async function () {
             const promise = Promise.resolve(choices);
-            mockWrapper.setup(x => x.workspaceFolders).returns(() => undefined);
+            mockWrapper.setup(x => x.workspaceFolders).returns(() => []);
             mockSubject.setup(x => x.packagePickerChoices()).
                 returns(() => promise);
             mockWrapper.setup(x => x.showQuickPick(promise,

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -14,6 +14,7 @@ import * as Packages from '../src/packages'
 import * as Tasks from '../src/tasks'
 import * as Syskit from '../src/syskit'
 import * as Config from '../src/config'
+import * as Watcher from '../src/watcher'
 import { EventEmitter } from 'events';
 import { writeFileSync } from 'fs';
 
@@ -215,6 +216,12 @@ export class TestSetup
         return this.mockConfigManager.target;
     }
 
+    mockFileWatcher : TypeMoq.IMock<Watcher.FileWatcher>;
+    get fileWatcher() : Watcher.FileWatcher
+    {
+        return this.mockFileWatcher.target;
+    }
+
     constructor()
     {
         this.mockWrapper = TypeMoq.Mock.ofType<Wrappers.VSCode>();
@@ -225,6 +232,7 @@ export class TestSetup
         this.mockPackageFactory = TypeMoq.Mock.ofType2(Packages.PackageFactory, [this.wrapper, this.taskProvider]);
         this.mockContext = TypeMoq.Mock.ofType2(Context.Context, [this.wrapper, this.workspaces, this.packageFactory, this.outputChannel]);
         this.mockConfigManager = TypeMoq.Mock.ofType2(Config.ConfigManager, [this.workspaces, this.wrapper])
+        this.mockFileWatcher = TypeMoq.Mock.ofType2(Watcher.FileWatcher, [])
     }
 
     setupWrapper(fn) {

--- a/test/vscode_workspace_manager.test.ts
+++ b/test/vscode_workspace_manager.test.ts
@@ -1,0 +1,86 @@
+'use strict';
+import * as assert from 'assert';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as vscode from 'vscode';
+import * as autoproj from '../src/autoproj';
+import * as helpers from './helpers';
+import * as TypeMoq from 'typemoq'
+import * as events from 'events';
+import * as url from 'url';
+
+import { Manager } from '../src/vscode_workspace_manager'
+
+describe("vscode_workspace_manager.Manager", function () {
+    let s: helpers.TestSetup;
+    let subject: Manager;
+
+    beforeEach(function () {
+        s = new helpers.TestSetup();
+        helpers.init();
+        subject = new Manager(s.context, s.workspaces, s.taskProvider,
+            s.mockConfigManager.object, s.fileWatcher);
+    })
+    afterEach(function () {
+        helpers.clear();
+    })
+
+    describe("handleNewFolder", function() {
+        it("ignores folders that are not part of a workspace", function() {
+            subject.handleNewFolder(0, '/some/where/over/the/rainbow');
+            s.mockWorkspaces.verify(x => x.addFolder(TypeMoq.It.isAny()),
+                TypeMoq.Times.never());
+        })
+
+        it("auto-adds the config folder on top of the workspace folder", function() {
+            let root = s.createWorkspace('ws');
+            s.mockWrapper.setup(x => x.workspaceFolders).returns(() => [])
+            subject.handleNewFolder(0, `${root}/base/types`);
+            let expectedFolder = { name: 'autoproj (ws)', uri: vscode.Uri.file(`${root}/autoproj`) }
+            s.mockWrapper.verify(x => x.updateWorkspaceFolders(0, null, expectedFolder),
+                TypeMoq.Times.once());
+            s.mockWorkspaces.verify(x => x.addFolder(TypeMoq.It.isAny()),
+                TypeMoq.Times.never())
+        })
+
+        it("sets up the workspace if it was not there already", async function() {
+            let { mock, ws } = s.createAndRegisterWorkspace('ws');
+            let info = ws.info();
+            let existing = [{ index: 0, name: 'autoproj (ws)',
+                uri: vscode.Uri.file(`${ws.root}/autoproj`) }]
+            s.mockWrapper.setup(x => x.workspaceFolders).returns(() => existing)
+            s.mockWorkspaces.setup(x => x.addFolder(`${ws.root}/autoproj`)).
+                returns(() => { return { added: true, workspace: mock.object } })
+
+            // mocking `subject` is a pain. We use these as a proxy to checking
+            // that setupNewWorkspace was called
+            //
+            // This forced me to somehow use mock.object instead of mock.target,
+            // which also forced me to setup all these method calls
+            mock.setup(x => x.info()).returns(() => info)
+            mock.setup(x => x.reload()).returns(() => info)
+            mock.setup(x => x.ensureSyskitContextAvailable()).
+                returns(() => Promise.resolve())
+
+            s.mockConfigManager.setup(x => x.setupPackage(`${ws.root}/autoproj`)).
+                returns(() => Promise.resolve(true));
+            subject.handleNewFolder(0, `${ws.root}/autoproj`);
+            mock.verify(x => x.ensureSyskitContextAvailable(),
+                TypeMoq.Times.once());
+            s.mockConfigManager.verify(x => x.setupPackage(`${ws.root}/autoproj`),
+                TypeMoq.Times.once());
+        })
+
+        it("only sets up the package configuration if the workspace was registered", async function() {
+            let { mock, ws } = s.createAndRegisterWorkspace('ws');
+            let existing = [{ index: 0, name: 'autoproj (ws)',
+                uri: vscode.Uri.file(`${ws.root}/autoproj`) }]
+            s.mockConfigManager.setup(x => x.setupPackage(`${ws.root}/test`)).
+                returns(() => Promise.resolve(true));
+            s.mockWrapper.setup(x => x.workspaceFolders).returns(() => existing)
+            subject.handleNewFolder(0, `${ws.root}/test`);
+            s.mockConfigManager.verify(x => x.setupPackage(`${ws.root}/test`),
+                TypeMoq.Times.once());
+        })
+    })
+})

--- a/test/vscode_workspace_manager.test.ts
+++ b/test/vscode_workspace_manager.test.ts
@@ -83,4 +83,36 @@ describe("vscode_workspace_manager.Manager", function () {
                 TypeMoq.Times.once());
         })
     })
+
+    describe("handleDeletedFolder", function() {
+        let mock : any;
+        let ws : autoproj.Workspace;
+        let folder : string;
+
+        beforeEach(function() {
+            let ret = s.createAndRegisterWorkspace('ws');
+            mock = ret.mock; ws = ret.ws;
+            folder = helpers.mkdir('ws', 'a');
+            s.workspaces.addFolder(folder);
+        })
+
+        it("does not dispose of the workspace if there is a folder still", function() {
+            let otherFolder = helpers.mkdir('ws', 'b');
+            s.workspaces.addFolder(otherFolder);
+
+            let disposed = false;
+            let disposable = new vscode.Disposable(() => disposed = true);
+            ws.subscribe(disposable);
+            subject.handleDeletedFolder(folder);
+            assert.strictEqual(disposed, false);
+        })
+
+        it("disposes of the workspace when the last folder is removed", function() {
+            let disposed = false;
+            let disposable = new vscode.Disposable(() => disposed = true);
+            ws.subscribe(disposable);
+            subject.handleDeletedFolder(folder);
+            assert.strictEqual(disposed, true);
+        })
+    })
 })


### PR DESCRIPTION
This pull request improves having multiple Autoproj workspaces in a single VSCode workspace. In addition, it workarounds an issue related to VSCode's handling of the very first folder in the workspace.

First the vscode issue. VSCode will restart the extension hosts if the toplevel folder in a VSCode workspace changes (because it needs to change the now-obsolete `rootPath` property). This leads to the extension attempting to start a Watch while there is already one. The first attempt was to make sure we deregister the watch task using the new Task execution APIs. This is a great addition in the first place, but proved fruitless as it seems that vscode doesn't shut down the extensions cleanly (I wouldn't get the extension's `deactivate` function or any of the `dispose` methods to be called). I then tried to use the `taskExecutions` property to find the watch task, but it is also empty - don't really know why.

_In fine_, I tried to see a way to make sure the first folder doesn't change this much. This led me to think about a problem I recently had, to use two autoproj workspaces in the same vscode workspace (comparing code). This was hell, as the packages would be named the same.

So, I went for:
- always having the workspace's `autoproj` folder added to the vscode workspace, and name it as the workspace (e.g. `autoproj (squidbot)`).
- use the `autoproj` folder as a guard, i.e. folders for the squidbot workspace would be placed after the `autoproj (squidbot)` folder. Moreover, they would be placed **before** the following folder that is not part of the workspace project.

Because the folder names can't be changed after they have been added, I also created a `Rock: Add Workspace` command for the initial add. The one corner case is if someone adds the autoproj folder directly.

Illustration:

![vscode-multi-workspace](https://user-images.githubusercontent.com/292/53565196-86a96800-3b37-11e9-9e1d-8ab1c8eebcc8.png)
