### PR TITLE
split "tooling" from "editor" settings and optionally auto-apply the former

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,6 +53,16 @@
                     "type": "string",
                     "default": null,
                     "description": "Toplevel path in which your workspaces are stored, to speed up selection in the Add Workspace command"
+                },
+                "rock.applyRubySettings": {
+                    "type": "boolean",
+                    "default": true,
+                    "description": "Whether the recommended Ruby settings should be set on new workspaces"
+                },
+                "rock.applyCPPSettings": {
+                    "type": "boolean",
+                    "default": true,
+                    "description": "Whether the recommended C++ settings should be set on new workspaces"
                 }
             }
         },
@@ -138,7 +148,22 @@
             {
                 "title": "Update VS Code configuration",
                 "category": "Rock",
-                "command": "rock.updateCodeConfig"
+                "command": "rock.applyDefaultSettings"
+            },
+            {
+                "title": "Apply Recommended Editor Settings",
+                "category": "Rock",
+                "command": "rock.applyEditorSettings"
+            },
+            {
+                "title": "Apply Recommended C++ Settings",
+                "category": "Rock",
+                "command": "rock.applyCPPSettings"
+            },
+            {
+                "title": "Apply Recommended Ruby Settings",
+                "category": "Rock",
+                "command": "rock.applyRubySettings"
             },
             {
                 "title": "Show Output",

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -158,7 +158,7 @@ export class Commands
         }
     }
 
-    async updateCodeConfig()
+    async pickConfigTarget() : Promise<vscode.ConfigurationTarget | undefined>
     {
         let choices: { label, description, configTarget }[] = [];
         function addChoice(label: string, scope: vscode.ConfigurationTarget)
@@ -178,12 +178,7 @@ export class Commands
         }
         const configTarget = await this._vscode.showQuickPick(choices, options);
         if (configTarget) {
-            try {
-                this._configManager.updateCodeConfig(configTarget.configTarget);
-            }
-            catch (err) {
-                this._vscode.showErrorMessage(err.message);
-            }
+            return configTarget.configTarget;
         }
     }
 
@@ -295,11 +290,37 @@ export class Commands
         }
     }
 
+    async applySettings(f) : Promise<void> {
+        let target = await this.pickConfigTarget();
+
+        if (target === undefined) {
+            return;
+        }
+
+        try {
+            f(target);
+        }
+        catch(err) {
+            this._vscode.showErrorMessage(err.message);
+        }
+    }
+
     register()
     {
         this._vscode.registerAndSubscribeCommand('rock.updatePackageInfo', () => { this.updatePackageInfo() });
         this._vscode.registerAndSubscribeCommand('rock.addLaunchConfig', () => { this.addLaunchConfig() });
-        this._vscode.registerAndSubscribeCommand('rock.updateCodeConfig', () => { this.updateCodeConfig() });
+        this._vscode.registerAndSubscribeCommand('rock.applyDefaultSettings', () => {
+            this.applySettings((target) => this._configManager.applyDefaultSettings(target));
+        });
+        this._vscode.registerAndSubscribeCommand('rock.applyCPPSettings', () => {
+            this.applySettings((target) => this._configManager.applyCPPSettings(target));
+        });
+        this._vscode.registerAndSubscribeCommand('rock.applyRubySettings', () => {
+            this.applySettings((target) => this._configManager.applyRubySettings(target));
+        });
+        this._vscode.registerAndSubscribeCommand('rock.applyEditorSettings', () => {
+            this.applySettings((target) => this._configManager.applyEditorSettings(target));
+        });
         this._vscode.registerAndSubscribeCommand('rock.showOutputChannel', () => { this.showOutputChannel() });
         this._vscode.registerAndSubscribeCommand('rock.addPackageToWorkspace', () => { this.addPackageToWorkspace() });
         this._vscode.registerAndSubscribeCommand('rock.addWorkspace', () => { this.addWorkspace() });

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -17,6 +17,7 @@ import { Manager as VSCodeWorkspaceManager } from './vscode_workspace_manager';
 function applyConfiguration(configManager : config.ConfigManager,
     workspaces : autoproj.Workspaces) : void {
     workspaces.devFolder = configManager.getDevFolder();
+    configManager.autoApplySettings();
 }
 
 // this method is called when your extension is activated

--- a/src/vscode_workspace_manager.ts
+++ b/src/vscode_workspace_manager.ts
@@ -113,6 +113,7 @@ export class Manager {
         folders.forEach((folder) => {
             index = this.handleNewFolder(index, folder.uri.fsPath);
         });
+        this._configManager.autoApplySettings();
     }
 
     handleDeletedFolder(path: string) {
@@ -131,5 +132,6 @@ export class Manager {
         event.removed.forEach((folder) => {
             this.handleDeletedFolder(folder.uri.fsPath);
         });
+        this._configManager.autoApplySettings();
     }
 };

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -246,7 +246,8 @@ describe("ConfigManager", function () {
             }
             mockSubject = TypeMoq.Mock.ofInstance(subject);
             mockConfiguration = TypeMoq.Mock.ofType<vscode.WorkspaceConfiguration>();
-            mockSubject.setup(x => x.suggestedSettings()).returns(() => mockSettings);
+            mockSubject.setup(x => x.suggestedEditorSettings(TypeMoq.It.isAny())).
+                returns(() => mockSettings);
             mockWrapper.setup(x => x.getConfiguration()).returns(() => mockConfiguration.object);
             subject = mockSubject.target;
         })
@@ -258,8 +259,7 @@ describe("ConfigManager", function () {
         }
         function testConfig(scope: vscode.ConfigurationTarget)
         {
-            subject.updateCodeConfig(scope);
-            mockWrapper.verify(x => x.getConfiguration(), TypeMoq.Times.once());
+            subject.applyDefaultSettings(scope);
             verifyConfig("some.property", "string", scope);
             verifyConfig("some.number", 31337, scope);
             verifyConfig("some.boolean", true, scope);


### PR DESCRIPTION
On the Ruby side, it ensures that workspaces have their 'bundler'
settings properly set for e.g. solargraph/rubocop, and that it will work
out of the box.

The editor settings - the more personal stuff - is left unchanged.