### PR TITLE
pass options to our gdb stub through miDebuggerArgs

### DIFF
--- a/src/debug.ts
+++ b/src/debug.ts
@@ -125,15 +125,11 @@ export class CXXConfigurationProvider extends ConfigurationProvider
         }
         else {
             config.miDebuggerPath = stubScript;
-            if (!config.environment) {
-                config.environment = [];
+            let args = `"${ws.autoprojExePath()}" "${debuggerPath}"`;
+            if (config.miDebuggerArgs) {
+                args = `${args} ${config.miDebuggerArgs}`;
             }
-            config.environment = config.environment.concat([
-                { name: "VSCODE_ROCK_AUTOPROJ_PATH", value: ws.autoprojExePath() },
-                { name: "VSCODE_ROCK_AUTOPROJ_DEBUGGER", value: debuggerPath },
-                { name: 'AUTOPROJ_CURRENT_ROOT', value: ws.root }
-            ])
-
+            config.miDebuggerArgs = args;
         }
 
         return config;

--- a/stubs/gdb
+++ b/stubs/gdb
@@ -1,3 +1,6 @@
 #! /bin/sh
 
-exec "$VSCODE_ROCK_AUTOPROJ_PATH" exec "$VSCODE_ROCK_AUTOPROJ_DEBUGGER" "$@"
+autoproj_path=$1
+shift
+
+exec "$autoproj_path" exec "$@"


### PR DESCRIPTION
Until now, we were using the `environment` array. It seems that the
latest update started passing the environment through commands to
the debugger instead of through the shell environment.

Passing it through miDebuggerArgs seems to be the right thing to
do anyways.