### PR TITLE
fix stubs/gdb to be independent of the order of vscode-provided arguments

### DIFF
--- a/stubs/gdb
+++ b/stubs/gdb
@@ -1,6 +1,14 @@
-#! /bin/sh
+#! /bin/bash
 
-autoproj_path=$1
-shift
+newparams=()
+for param; do
+    if [[ "$param" == -* ]]; then
+        newparams+=("$param")
+    elif test -z "$autoproj_path"; then
+        autoproj_path=$param
+    elif test -z "$debugger"; then
+        debugger=$param
+    fi
+done
 
-exec "$autoproj_path" exec "$@"
+exec "$autoproj_path" exec "$debugger" "${newparams[@]}"


### PR DESCRIPTION
It seems that in some cases the C++ extension will add arguments before
our own to the stub script. Luckily, all vscode-provided arguments
are `--` arguments, so filter on that.