### PR TITLE
match provider type in TaskDefinition and registerTaskProvider

### DIFF
--- a/package.json
+++ b/package.json
@@ -351,11 +351,11 @@
                     "mode": {
                         "type": "string",
                         "enum": [
-                            "update",
-                            "checkout",
                             "build",
+                            "checkout",
+                            "force-build",
                             "build-no-deps",
-                            "force-build"
+                            "update"
                         ],
                         "description": "The operation mode"
                     }
@@ -375,11 +375,12 @@
                     "mode": {
                         "type": "string",
                         "enum": [
-                            "osdeps",
                             "watch",
+                            "build",
+                            "checkout",
+                            "osdeps",
                             "update-config",
-                            "update",
-                            "checkout"
+                            "update"
                         ],
                         "description": "The operation mode"
                     }

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -186,10 +186,16 @@ export class TestSetup
         return this.mockWorkspaces.target;
     }
 
-    mockTaskProvider : TypeMoq.IMock<Tasks.AutoprojProvider>;
-    get taskProvider()
+    mockWorkspaceTaskProvider : TypeMoq.IMock<Tasks.AutoprojWorkspaceTaskProvider>;
+    get workspaceTaskProvider()
     {
-        return this.mockTaskProvider.target;
+        return this.mockWorkspaceTaskProvider.target;
+    }
+
+    mockPackageTaskProvider : TypeMoq.IMock<Tasks.AutoprojPackageTaskProvider>;
+    get packageTaskProvider()
+    {
+        return this.mockPackageTaskProvider.target;
     }
 
     mockPackageFactory : TypeMoq.IMock<Packages.PackageFactory>;
@@ -228,8 +234,9 @@ export class TestSetup
 
         this.mockOutputChannel = TypeMoq.Mock.ofType2(OutputChannel, []);
         this.mockWorkspaces = TypeMoq.Mock.ofType2(Autoproj.Workspaces, [undefined, this.outputChannel]);
-        this.mockTaskProvider = TypeMoq.Mock.ofType2(Tasks.AutoprojProvider, [this.workspaces]);
-        this.mockPackageFactory = TypeMoq.Mock.ofType2(Packages.PackageFactory, [this.wrapper, this.taskProvider]);
+        this.mockWorkspaceTaskProvider = TypeMoq.Mock.ofType2(Tasks.AutoprojWorkspaceTaskProvider, [this.workspaces]);
+        this.mockPackageTaskProvider = TypeMoq.Mock.ofType2(Tasks.AutoprojPackageTaskProvider, [this.workspaces]);
+        this.mockPackageFactory = TypeMoq.Mock.ofType2(Packages.PackageFactory, [this.wrapper]);
         this.mockContext = TypeMoq.Mock.ofType2(Context.Context, [this.wrapper, this.workspaces, this.packageFactory, this.outputChannel]);
         this.mockConfigManager = TypeMoq.Mock.ofType2(Config.ConfigManager, [this.workspaces, this.wrapper])
         this.mockFileWatcher = TypeMoq.Mock.ofType2(Watcher.FileWatcher, [])

--- a/test/packages.test.ts
+++ b/test/packages.test.ts
@@ -203,12 +203,10 @@ describe("ForeignPackage", function () {
 describe("RockRubyPackage", function () {
     let subject: packages.RockRubyPackage;
     let mockContext: TypeMoq.IMock<context.Context>;
-    let mockTaskProvider: TypeMoq.IMock<tasks.AutoprojProvider>;
     let mockWrapper: TypeMoq.IMock<wrappers.VSCode>;
     let workspace: autoproj.Workspace;
     beforeEach(function () {
         mockContext = TypeMoq.Mock.ofType<context.Context>();
-        mockTaskProvider = TypeMoq.Mock.ofType<tasks.AutoprojProvider>();
         mockWrapper = TypeMoq.Mock.ofType<wrappers.VSCode>();
         workspace = new autoproj.Workspace("path", false);
         subject = new packages.RockRubyPackage(workspace,
@@ -250,7 +248,6 @@ describe("RockRubyPackage", function () {
 describe("RockCXXPackage", function () {
     let subject: packages.RockCXXPackage;
     let mockContext: TypeMoq.IMock<context.Context>;
-    let mockTaskProvider: TypeMoq.IMock<tasks.AutoprojProvider>;
     let mockWrapper: TypeMoq.IMock<wrappers.VSCode>;
     let workspace: autoproj.Workspace;
     beforeEach(function () {
@@ -259,7 +256,6 @@ describe("RockCXXPackage", function () {
             'Autobuild::CMake', "/path/to/package");
         pkgInfo.builddir = "/path/to/package/build";
         mockContext = TypeMoq.Mock.ofType<context.Context>();
-        mockTaskProvider = TypeMoq.Mock.ofType<tasks.AutoprojProvider>();
         mockWrapper = TypeMoq.Mock.ofType<wrappers.VSCode>();
         subject = new packages.RockCXXPackage(workspace, pkgInfo,
             mockContext.object, mockWrapper.object);
@@ -320,7 +316,6 @@ describe("RockCXXPackage", function () {
 describe("RockOtherPackage", function () {
     let subject: packages.RockOtherPackage;
     let mockContext: TypeMoq.IMock<context.Context>;
-    let mockTaskProvider: TypeMoq.IMock<tasks.AutoprojProvider>;
     let mockWrapper: TypeMoq.IMock<wrappers.VSCode>;
     let pkgInfo: autoproj.Package;
     let workspace: autoproj.Workspace;
@@ -341,7 +336,6 @@ describe("RockOtherPackage", function () {
     beforeEach(function () {
         pkgInfo = nullPackageInfo("/path/to/package");
         mockContext = TypeMoq.Mock.ofType<context.Context>();
-        mockTaskProvider = TypeMoq.Mock.ofType<tasks.AutoprojProvider>();
         mockWrapper = TypeMoq.Mock.ofType<wrappers.VSCode>();
         workspace = new autoproj.Workspace("path", false);
         subject = new packages.RockOtherPackage(workspace,
@@ -441,7 +435,7 @@ describe("RockOrogenPackage", function () {
         it("returns a debug configuration for a selected deployment", async function () {
             s.mockContext.setup(x => x.pickTask(subject.workspace)).
                 returns(() => Promise.resolve(deployments[1]));
-            setupSubject();   
+            setupSubject();
             const expectedCustomDebugConfig: vscode.DebugConfiguration = {
                 name: "orogen - test_deployment",
                 type: "orogen",

--- a/test/tasks.test.ts
+++ b/test/tasks.test.ts
@@ -6,11 +6,72 @@ import * as tasks from '../src/tasks';
 import { basename, relative } from 'path';
 import * as vscode from 'vscode';
 
-
-describe("Task provider", function () {
+function assertTask(task: vscode.Task, process: string, args: string[])
+{
+    let actual_process = (<vscode.ProcessExecution>task.execution).process;
+    let actual_args = (<vscode.ProcessExecution>task.execution).args;
+    assert.equal(actual_process, process);
+    assert.deepEqual(actual_args, args);
+}
+function autoprojExePath(basePath)
+{
+    let wsRoot = autoproj.findWorkspaceRoot(basePath) as string;
+    return autoproj.autoprojExePath(wsRoot);
+}
+function assertWatchTask(task: vscode.Task, path: string)
+{
+    let process = autoprojExePath(path);
+    let args = ['watch', '--show-events'];
+    assertTask(task, process, args);
+}
+function assertBuildTask(task: vscode.Task, path: string, isPackage = true)
+{
+    let process = autoprojExePath(path);
+    let args = ['build', '--tool']; if (isPackage) args.push(path);
+    assertTask(task, process, args);
+}
+function assertForceBuildTask(task: vscode.Task, path: string)
+{
+    let process = autoprojExePath(path);
+    let args = ['build', '--tool', '--force', '--deps=f', '--no-confirm', path];
+    assertTask(task, process, args);
+}
+function assertNodepsBuildTask(task: vscode.Task, path: string)
+{
+    let process = autoprojExePath(path);
+    let args = ['build', '--tool', '--deps=f', path];
+    assertTask(task, process, args);
+}
+function assertUpdateTask(task: vscode.Task, path: string, isPackage = true)
+{
+    let process = autoprojExePath(path);
+    let args = ['update', '--progress=f', '-k', '--color'];
+    if (isPackage) args.push(path);
+    assertTask(task, process, args);
+}
+function assertCheckoutTask(task: vscode.Task, path: string, isPackage = true)
+{
+    let process = autoprojExePath(path);
+    let args = ['update', '--progress=f', '-k', '--color', '--checkout-only'];
+    if (isPackage) args.push(path);
+    assertTask(task, process, args);
+}
+function assertOsdepsTask(task: vscode.Task, path: string)
+{
+    let process = autoprojExePath(path);
+    let args = ['osdeps', '--color'];
+    assertTask(task, process, args);
+}
+function assertUpdateConfigTask(task: vscode.Task, path: string)
+{
+    let process = autoprojExePath(path);
+    let args = ['update', '--progress=f', '-k', '--color', '--config'];
+    assertTask(task, process, args);
+}
+describe("Workspace task provider", function () {
     let root: string;
     let workspaces: autoproj.Workspaces;
-    let subject: tasks.AutoprojProvider;
+    let subject: tasks.AutoprojWorkspaceTaskProvider;
 
     beforeEach(function () {
         root = helpers.init();
@@ -20,113 +81,28 @@ describe("Task provider", function () {
         helpers.clear();
     })
 
-    function assertTask(task: vscode.Task, process: string, args: string[])
-    {
-        let actual_process = (<vscode.ProcessExecution>task.execution).process;
-        let actual_args = (<vscode.ProcessExecution>task.execution).args;
-        assert.equal(actual_process, process);
-        assert.deepEqual(actual_args, args);
-    }
-    function autoprojExePath(basePath)
-    {
-        let wsRoot = autoproj.findWorkspaceRoot(basePath) as string;
-        return autoproj.autoprojExePath(wsRoot);
-    }
-    function assertWatchTask(task: vscode.Task, path: string)
-    {
-        let process = autoprojExePath(path);
-        let args = ['watch', '--show-events'];
-        assertTask(task, process, args);
-    }
-    function assertBuildTask(task: vscode.Task, path: string, isPackage = true)
-    {
-        let process = autoprojExePath(path);
-        let args = ['build', '--tool']; if (isPackage) args.push(path);
-        assertTask(task, process, args);
-    }
-    function assertForceBuildTask(task: vscode.Task, path: string)
-    {
-        let process = autoprojExePath(path);
-        let args = ['build', '--tool', '--force', '--deps=f', '--no-confirm', path];
-        assertTask(task, process, args);
-    }
-    function assertNodepsBuildTask(task: vscode.Task, path: string)
-    {
-        let process = autoprojExePath(path);
-        let args = ['build', '--tool', '--deps=f', path];
-        assertTask(task, process, args);
-    }
-    function assertUpdateTask(task: vscode.Task, path: string, isPackage = true)
-    {
-        let process = autoprojExePath(path);
-        let args = ['update', '--progress=f', '-k', '--color'];
-        if (isPackage) args.push(path);
-        assertTask(task, process, args);
-    }
-    function assertCheckoutTask(task: vscode.Task, path: string, isPackage = true)
-    {
-        let process = autoprojExePath(path);
-        let args = ['update', '--progress=f', '-k', '--color', '--checkout-only'];
-        if (isPackage) args.push(path);
-        assertTask(task, process, args);
-    }
-    function assertOsdepsTask(task: vscode.Task, path: string)
-    {
-        let process = autoprojExePath(path);
-        let args = ['osdeps', '--color'];
-        assertTask(task, process, args);
-    }
-    function assertUpdateConfigTask(task: vscode.Task, path: string)
-    {
-        let process = autoprojExePath(path);
-        let args = ['update', '--progress=f', '-k', '--color', '--config'];
-        assertTask(task, process, args);
-    }
-    function assertAllPackageTasks(path: string)
-    {
-        let buildTask = subject.buildTask(path);
-        assert.notEqual(buildTask, undefined);
-        assertBuildTask(buildTask, path);
-
-        let nodepsBuildTask = subject.nodepsBuildTask(path);
-        assert.notEqual(nodepsBuildTask, undefined);
-        assertNodepsBuildTask(nodepsBuildTask, path);
-
-        let forceBuildTask = subject.forceBuildTask(path);
-        assert.notEqual(forceBuildTask, undefined);
-        assertForceBuildTask(forceBuildTask, path);
-
-        let updateTask = subject.updateTask(path);
-        assert.notEqual(updateTask, undefined);
-        assertUpdateTask(updateTask, path);
-
-        let checkoutTask = subject.checkoutTask(path);
-        assert.notEqual(checkoutTask, undefined);
-        assertCheckoutTask(checkoutTask, path);
-    }
-
-    function assertAllWorkspaceTasks(wsRoot: string) {
-        let watchTask = subject.watchTask(wsRoot);
+    function assertAllWorkspaceTasks(provider, wsRoot: string) {
+        let watchTask = provider.watchTask(wsRoot);
         assert.notEqual(watchTask, undefined);
         assertWatchTask(watchTask, wsRoot);
 
-        let buildTask = subject.buildTask(wsRoot);
+        let buildTask = provider.buildTask(wsRoot);
         assert.notEqual(buildTask, undefined);
         assertBuildTask(buildTask, wsRoot, false);
 
-        let checkoutTask = subject.checkoutTask(wsRoot);
+        let checkoutTask = provider.checkoutTask(wsRoot);
         assert.notEqual(checkoutTask, undefined);
         assertCheckoutTask(checkoutTask, wsRoot, false);
 
-        let osdepsTask = subject.osdepsTask(wsRoot);
+        let osdepsTask = provider.osdepsTask(wsRoot);
         assert.notEqual(osdepsTask, undefined);
         assertOsdepsTask(osdepsTask, wsRoot);
 
-        let updateConfigTask = subject.updateConfigTask(wsRoot);
+        let updateConfigTask = provider.updateConfigTask(wsRoot);
         assert.notEqual(updateConfigTask, undefined);
         assertUpdateConfigTask(updateConfigTask, wsRoot);
 
-        let updateTask = subject.updateTask(wsRoot);
+        let updateTask = provider.updateTask(wsRoot);
         assert.notEqual(updateTask, undefined);
         assertUpdateTask(updateTask, wsRoot, false);
     }
@@ -160,29 +136,121 @@ describe("Task provider", function () {
             workspaces.addFolder(c);
             workspaces.addFolder(d);
             workspaces.addFolder(e);
-            subject = new tasks.AutoprojProvider(workspaces);
+            subject = new tasks.AutoprojWorkspaceTaskProvider(workspaces);
         })
 
         it("is initalized with all tasks", function () {
             let tasks = subject.provideTasks(null);
-            assert.equal(tasks.length, 27);
+            assert.equal(tasks.length, 12);
         })
         it("is initalized with all workspace tasks", function () {
-            let tasks = subject.provideTasks(null);
-            assertAllWorkspaceTasks(wsOneRoot);
-            assertAllWorkspaceTasks(wsTwoRoot);
-        });
-        it("is initalized with all package tasks", function () {
-            let tasks = subject.provideTasks(null);
-            assertAllPackageTasks(a);
-            assertAllPackageTasks(b);
-            assertAllPackageTasks(c);
+            assertAllWorkspaceTasks(subject, wsOneRoot);
+            assertAllWorkspaceTasks(subject, wsTwoRoot);
         });
     });
 
     describe("in an empty workspace", function () {
         beforeEach(function () {
-            subject = new tasks.AutoprojProvider(workspaces);
+            subject = new tasks.AutoprojWorkspaceTaskProvider(workspaces);
+        });
+        it("does not provide any tasks", function () {
+            let tasks = subject.provideTasks(null);
+            assert.equal(tasks.length, 0);
+        })
+        it("creates tasks when folders/workspaces are added", function () {
+            helpers.mkdir('.autoproj');
+            helpers.createInstallationManifest([]);
+            helpers.mkdir('drivers');
+
+            let a = helpers.mkdir('drivers', 'iodrivers_base');
+            workspaces.addFolder(a);
+            subject.reloadTasks();
+
+            let tasks = subject.provideTasks(null);
+            assert.equal(tasks.length, 6);
+            assertAllWorkspaceTasks(subject, helpers.fullPath());
+        })
+    });
+});
+
+describe("Package task provider", function () {
+    let root: string;
+    let workspaces: autoproj.Workspaces;
+    let subject: tasks.AutoprojPackageTaskProvider;
+
+    beforeEach(function () {
+        root = helpers.init();
+        workspaces = new autoproj.Workspaces()
+    })
+    afterEach(function () {
+        helpers.clear();
+    })
+
+    function assertAllPackageTasks(provider, path: string)
+    {
+        let buildTask = provider.buildTask(path);
+        assert.notEqual(buildTask, undefined);
+        assertBuildTask(buildTask, path);
+
+        let forceBuildTask = provider.forceBuildTask(path);
+        assert.notEqual(forceBuildTask, undefined);
+        assertForceBuildTask(forceBuildTask, path);
+
+        let updateTask = provider.updateTask(path);
+        assert.notEqual(updateTask, undefined);
+        assertUpdateTask(updateTask, path);
+
+        let checkoutTask = provider.checkoutTask(path);
+        assert.notEqual(checkoutTask, undefined);
+        assertCheckoutTask(checkoutTask, path);
+    }
+
+    describe("in a non empty workspace", function () {
+        let wsOneRoot: string;
+        let wsTwoRoot: string;
+        let a: string;
+        let b: string;
+        let c: string;
+        let d: string;
+        let e: string;
+        beforeEach(function () {
+            wsOneRoot = helpers.mkdir('one');
+            wsTwoRoot = helpers.mkdir('two');
+            helpers.mkdir('one', '.autoproj');
+            helpers.mkdir('two', '.autoproj');
+            d = helpers.mkdir('one', 'autoproj');
+            e = helpers.mkdir('two', 'autoproj');
+
+            helpers.createInstallationManifest([], 'one');
+            helpers.createInstallationManifest([], 'two');
+            helpers.mkdir('one', 'drivers');
+            helpers.mkdir('two', 'firmware');
+            a = helpers.mkdir('one', 'drivers', 'iodrivers_base');
+            b = helpers.mkdir('one', 'drivers', 'auv_messaging');
+            c = helpers.mkdir('two', 'firmware', 'chibios');
+
+            workspaces.addFolder(a);
+            workspaces.addFolder(b);
+            workspaces.addFolder(c);
+            workspaces.addFolder(d);
+            workspaces.addFolder(e);
+            subject = new tasks.AutoprojPackageTaskProvider(workspaces);
+        })
+
+        it("is initalized with all tasks", function () {
+            let tasks = subject.provideTasks(null);
+            assert.equal(tasks.length, 15);
+        })
+        it("is initalized with all package tasks", function () {
+            assertAllPackageTasks(subject, a);
+            assertAllPackageTasks(subject, b);
+            assertAllPackageTasks(subject, c);
+        });
+    });
+
+    describe("in an empty workspace", function () {
+        beforeEach(function () {
+            subject = new tasks.AutoprojPackageTaskProvider(workspaces);
         });
         it("provides an empty array of tasks", function () {
             let tasks = subject.provideTasks(null);
@@ -198,9 +266,8 @@ describe("Task provider", function () {
             subject.reloadTasks();
 
             let tasks = subject.provideTasks(null);
-            assert.equal(tasks.length, 11);
-            assertAllWorkspaceTasks(helpers.fullPath());
-            assertAllPackageTasks(a);
+            assert.equal(tasks.length, 5);
+            assertAllPackageTasks(subject, a);
         })
     });
 });

--- a/test/vscode_workspace_manager.test.ts
+++ b/test/vscode_workspace_manager.test.ts
@@ -18,7 +18,8 @@ describe("vscode_workspace_manager.Manager", function () {
     beforeEach(function () {
         s = new helpers.TestSetup();
         helpers.init();
-        subject = new Manager(s.context, s.workspaces, s.taskProvider,
+        subject = new Manager(
+            s.context, s.workspaces, s.workspaceTaskProvider, s.packageTaskProvider,
             s.mockConfigManager.object, s.fileWatcher);
     })
     afterEach(function () {
@@ -54,7 +55,7 @@ describe("vscode_workspace_manager.Manager", function () {
             s.mockConfigManager.setup(x => x.setupPackage(`${root}/base/types`)).
                 returns(() => Promise.resolve(true));
             subject.handleNewFolder(0, `${root}/base/types`);
-            assert(s.taskProvider.watchTask(`${root}`))
+            assert(s.workspaceTaskProvider.watchTask(`${root}`))
         })
 
         it("adds the tasks of the new folder in a new workspace", function() {
@@ -68,7 +69,7 @@ describe("vscode_workspace_manager.Manager", function () {
             s.mockConfigManager.setup(x => x.setupPackage(`${root}/base/types`)).
                 returns(() => Promise.resolve(true));
             subject.handleNewFolder(0, `${root}/base/types`);
-            assert(s.taskProvider.updateTask(`${root}/base/types`))
+            assert(s.packageTaskProvider.updateTask(`${root}/base/types`))
         })
 
         it("adds the tasks of a new folder in an existing workspace", function() {
@@ -85,7 +86,7 @@ describe("vscode_workspace_manager.Manager", function () {
                 returns(() => Promise.resolve(true));
             subject.handleNewFolder(0, `${root}/autoproj`);
             subject.handleNewFolder(0, `${root}/base/types`);
-            assert(s.taskProvider.updateTask(`${root}/base/types`))
+            assert(s.packageTaskProvider.updateTask(`${root}/base/types`))
         })
 
         it("sets up the workspace if it was not there already", async function() {


### PR DESCRIPTION
1.44.x's new task pick won't work with different names. The
symptom are tasks in the Recent list that don't work, and
the per-provider presentation of tasks that does not work either.

See https://github.com/microsoft/vscode/issues/95971