### PR TITLE
fix: workaround additional arguments that now appear in gdb command line

### DIFF
--- a/stubs/gdb
+++ b/stubs/gdb
@@ -4,6 +4,10 @@ newparams=()
 for param; do
     if [[ "$param" == -* ]]; then
         newparams+=("$param")
+    elif test "$param" = "$0"; then
+	continue
+    elif test "$param" = "$autoproj_path"; then
+	continue
     elif test -z "$autoproj_path"; then
         autoproj_path=$param
     elif test -z "$debugger"; then


### PR DESCRIPTION
Trying to run an orogen target now passes `--interpreter=mi $AUTOPROJ_PATH $GDB_STUB_PATH $AUTOPROJ_PATH gdb`.

While finding out why and fixing it in the code would probably be best (!), I don't have the time for it right now, and it might break with older vscode versions - which I regularly have to come back to because of weird vscode breakages.